### PR TITLE
fix(import aliases): strip quotes on multi-word expansions

### DIFF
--- a/tests/tests.zsh
+++ b/tests/tests.zsh
@@ -162,4 +162,97 @@ echo $message
 abbr -e $abbreviation
 echo
 
+# Can import aliases
+abbreviation=zsh_abbr_test_alias
+expansion=abc
+message="importing a single-word alias "
+alias $abbreviation=$expansion
+abbr --import-aliases
+if [[ $(abbr --expand $abbreviation) == $expansion ]]; then
+	message+="passed"
+else
+	message+="failed"
+fi
+echo $message
+abbr -e $abbreviation
+echo
+unalias $abbreviation
+rm $ZSH_ABBR_USER_PATH
+touch $ZSH_ABBR_USER_PATH
+source ${0:A:h}/../zsh-abbr.zsh
+
+# Can import a multi-word alias
+abbreviation=zsh_abbr_test_alias
+expansion="a b"
+message="importing a multi-word alias "
+alias $abbreviation=$expansion
+abbr --import-aliases
+if [[ $(abbr --expand $abbreviation) == $expansion ]]; then
+	message+="passed"
+else
+	message+="failed"
+fi
+echo $message
+abbr -e $abbreviation
+echo
+unalias $abbreviation
+rm $ZSH_ABBR_USER_PATH
+touch $ZSH_ABBR_USER_PATH
+source ${0:A:h}/../zsh-abbr.zsh
+
+# Can import a double-quoted alias with escaped double quotation marks
+abbreviation=zsh_abbr_test_alias
+expansion="a \"b\""
+message="importing a double-quoted multi-word alias with escape double quotes "
+alias $abbreviation=$expansion
+abbr --import-aliases
+if [[ $(abbr --expand $abbreviation) == $expansion ]]; then
+	message+="passed"
+else
+	message+="failed"
+fi
+echo $message
+abbr -e $abbreviation
+echo
+unalias $abbreviation
+rm $ZSH_ABBR_USER_PATH
+touch $ZSH_ABBR_USER_PATH
+source ${0:A:h}/../zsh-abbr.zsh
+
+# Can import a single-quoted alias with double quotation marks
+abbreviation=zsh_abbr_test_alias
+expansion='a "b"'
+message="importing a single-quoted multi-word alias with double quotes "
+alias $abbreviation=$expansion
+abbr --import-aliases
+if [[ $(abbr --expand $abbreviation) == $expansion ]]; then
+	message+="passed"
+else
+	message+="failed"
+fi
+echo $message
+abbr -e $abbreviation
+echo
+unalias $abbreviation
+rm $ZSH_ABBR_USER_PATH
+touch $ZSH_ABBR_USER_PATH
+source ${0:A:h}/../zsh-abbr.zsh
+
+# Can import a double-quoted alias with single quotation marks
+abbreviation=zsh_abbr_test_alias
+expansion="a 'b'"
+message="importing a double-quoted multi-word alias with single quotes "
+alias $abbreviation=$expansion
+abbr --import-aliases
+if [[ $(abbr --expand $abbreviation) == $expansion ]]; then
+	message+="passed"
+else
+	message+="failed"
+fi
+echo $message
+abbr -e $abbreviation
+echo
+unalias $abbreviation
+
+
 rm $ZSH_ABBR_USER_PATH

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -203,12 +203,14 @@ _zsh_abbr() {
       fi
 
       while read -r _alias; do
+        _alias=$(sed "s/='/=/; s/'$//" <<< "$_alias")
         _zsh_abbr:add $_alias
       done < <(alias -r)
 
       type='global'
 
       while read -r _alias; do
+        _alias=$(sed "s/='/=/; s/'$//" <<< "$_alias")
         _zsh_abbr:add $_alias
       done < <(alias -g)
 

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -196,6 +196,8 @@ _zsh_abbr() {
       (( ZSH_ABBR_DEBUG )) && echo "_zsh_abbr:import_aliases"
 
       local _alias
+      local abbreviation
+      local expansion
 
       if [[ $# > 0 ]]; then
         _zsh_abbr:util_error " import-aliases: Unexpected argument"
@@ -203,15 +205,13 @@ _zsh_abbr() {
       fi
 
       while read -r _alias; do
-        _alias=$(sed "s/='/=/; s/'$//" <<< "$_alias")
-        _zsh_abbr:add $_alias
+        _zsh_abbr:util_import_alias $_alias
       done < <(alias -r)
 
       type='global'
 
       while read -r _alias; do
-        _alias=$(sed "s/='/=/; s/'$//" <<< "$_alias")
-        _zsh_abbr:add $_alias
+        _zsh_abbr:util_import_alias $_alias
       done < <(alias -g)
 
       if ! (( dry_run )); then
@@ -504,6 +504,16 @@ _zsh_abbr() {
       should_exit=1
     }
 
+    function _zsh_abbr:util_import_alias() {
+      local abbreviation
+      local expansion
+
+      abbreviation=${1%%=*}
+      expansion=${1#*=}
+
+      _zsh_abbr:util_add $abbreviation "$(echo $expansion)"
+    }
+
     function _zsh_abbr:util_list() {
       (( ZSH_ABBR_DEBUG )) && echo "_zsh_abbr:util_list"
 
@@ -754,6 +764,7 @@ _zsh_abbr() {
     unfunction -m _zsh_abbr:util_add
     unfunction -m _zsh_abbr:util_alias
     unfunction -m _zsh_abbr:util_error
+    unfunction -m _zsh_abbr:util_import_alias
     unfunction -m _zsh_abbr:util_list
     unfunction -m _zsh_abbr:util_list_item
     unfunction -m _zsh_abbr:util_set_once


### PR DESCRIPTION
A "picture" is worth a thousand words:

[![asciicast](https://asciinema.org/a/EEMMCgurK7YXe8RVgKRfn1OVe.svg)](https://asciinema.org/a/EEMMCgurK7YXe8RVgKRfn1OVe)

In essence, `abbr --import-aliases` currently interprets the single
quotes surrounding multiple-word expansions a little too literally.

The proposed patch simply feeds each imported alias through a `sed`
command that removes the quotes before passing the alias to `:add()`.
The `alias` shell builtin always supplies such expansions in single
quotes and it's exceedingly unlikely that an alias would contain `'`,
so the command should be "as simple as possible, but no simpler".