### PR TITLE
v4.0.0 (wip)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Check the [Issues](https://github.com/olets/zsh-abbr/issues) to see if your topi
 
 This project loosely follows the [Angular commit message conventions](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit). This helps with searchability and with the changelog, which is generated automatically and touched up by hand only if necessary. Use the commit message format `<type>(<scope>): <subject>`, where `<type>` is **feat** for new or changed behavior, **fix** for fixes, **docs** for documentation, **style** for under the hood changes related to for example zshisms, **refactor** for other refactors, **test** for tests, or **chore** chore for general maintenance (this will be used primarily by maintainers not contributors, for example for version bumps). `<scope>` is more loosely defined. Look at the [commit history](https://github.com/olets/zsh-abbr/commits/master) for ideas.
 
-Tests are in the `tests` directory. To run them, replace `zsh-abbr` with `zsh-abbr/tests` in .zshrc. For example, zinit users will run
+Tests are in the `tests` directory. To run them, replace `zsh-abbr` with `zsh-abbr/tests` in `.zshrc`. For example, zinit users will run
 
 ```shell
 zinit ice lucid

--- a/README.md
+++ b/README.md
@@ -126,20 +126,16 @@ Clone this repo and add `source path/to/zsh-abbr.zsh` to your `.zshrc`.
 ## Usage
 
 ```shell
-abbr <SCOPE> <OPTION> <ANY OPTION ARGUMENTS>
+abbr [<SCOPE>] [<TYPE>] <OPTION> [<ARGS>]
 ```
 
-or
+Options which make changes can be passed `--dry-run`.
 
-```shell
-abbr <OPTION> <SCOPE> <ANY OPTION ARGUMENTS>
-```
+Options which have output can be passed `--quiet`.
+
+`<OPTION> [<ARGS>]` must be last.
 
 ### Scope
-
-```shell
-[(--session | -S) | (--user | -U)]
-```
 
 A given abbreviation can be limited to the current zsh session (i.e. the current terminal) —these are called *session* abbreviations— or to all terminals —these are called *user* abbreviations. Select options take **scope** as an argument.
 
@@ -149,11 +145,7 @@ Default is user.
 
 ### Type
 
-```shell
-[(--global | -g) | (--regular | -r)]
-```
-
-zsh-abbr supports regular abbreviations, which match the word at the start of the command line, and global abbreviations, which match any word on the line. Select options take **type** as an argument.
+Regular abbreviations match the word at the start of the command line, and global abbreviations match any word on the line. Select options take **type** as an argument.
 
 Default is regular.
 
@@ -163,10 +155,10 @@ zsh-abbr has options to add, rename, and erase abbreviations; to add abbreviatio
 
 `abbr` with no arguments is shorthand for `abbr list-commands`. `abbr ...` with arguments is shorthand for `abbr add ...`.
 
-#### Add
+#### `add`
 
 ```shell
-abbr [(add | -a)] [(--session | -S) | (--user | -U)] [(--global | -g) | (--regular | -r)] [--dry-run] [--quiet] [--force] ABBREVIATION=EXPANSION
+abbr [(add | -a)] [<SCOPE>] [<TYPE>] [--dry-run] [--quiet] [--force] ABBREVIATION=EXPANSION
 ```
 
 Add a new abbreviation.
@@ -181,16 +173,12 @@ To add a global abbreviation, use the **--global** flag. Otherwise the new abbre
 % gcm[Enter] # expands and accepts git checkout master
 ```
 
-The following are equivalent:
+`add` is the default option, and does not need to be explicit:
 
 ```shell
-% abbr add --user gcm='git checkout master'
-% abbr a --user gcm='git checkout master'
-% abbr --user gcm='git checkout master'
-% abbr add -U gcm='git checkout master'
-% abbr a -U gcm='git checkout master'
-% abbr -U gcm='git checkout master'
-% abbr gcm='git checkout master'
+% abbr gco='git checkout'
+% gco[Space] # expands as git checkout
+% gco[Enter] # expands and accepts git checkout
 ```
 
 The ABBREVIATION must be only one word long.
@@ -212,7 +200,7 @@ Will error rather than overwrite an existing abbreviation.
 
 Will warn if the abbreviation would replace an existing command. To add in spite of the warning, use `--force`.
 
-#### Clear Sessions
+#### `clear-session`
 
 ```shell
 abbr (clear-session | c)
@@ -220,10 +208,10 @@ abbr (clear-session | c)
 
 Erase all session abbreviations.
 
-#### Erase
+#### `erase`
 
 ```shell
-abbr (erase | e) [(--session | -S) | (--user | -U)] [(--global | -g) | (--regular | -r)] [--dry-run] [--quiet] ABBREVIATION
+abbr (erase | e) [<SCOPE>] [<TYPE>] [--dry-run] [--quiet] ABBREVIATION
 ```
 
 Erase an abbreviation.
@@ -242,7 +230,7 @@ Switched to branch 'master'
 
 User abbreviations can also be manually erased from the `ABBR_USER_ABBREVIATIONS_FILE`. See **Storage** below.
 
-#### Expand
+a `expand`
 
 ```shell
 abbr (expand | x) ABBREVIATION
@@ -256,10 +244,10 @@ Output the ABBREVIATION's EXPANSION.
 git checkout
 ```
 
-#### Export Aliases
+#### `export-aliases`
 
 ```shell
-abbr export-aliases [(--session | -S) | (--user | -U)] [(--global | -g) | (--regular | -r)] [DESTINATION]
+abbr export-aliases [<SCOPE>] [<TYPE>] [DESTINATION]
 ```
 
 Export abbreviations as alias commands. Regular abbreviations follow global abbreviations. Session abbreviations follow user abbreviations.
@@ -283,9 +271,7 @@ alias g='git'
 alias g='git'
 ```
 
-#### Import
-
-##### Aliases
+#### `import-aliases`
 
 ```shell
 abbr import-aliases [<type>] [--dry-run] [--quiet]
@@ -307,40 +293,33 @@ Note that zsh-abbr does not lint the imported abbreviations. An effort is made t
 
 Use `--dry-run` to see what would result, without making any actual changes.
 
-##### Fish Abbreviations
+#### `import-fish`
 
 ```shell
-abbr import-fish [(--session | -S) | (--user | -U)] [(--global|-g)] FILE [--dry-run] [--quiet]
+abbr import-fish [<SCOPE>] FILE [--dry-run] [--quiet]
 ```
 
 Import fish abbr-syntax abbreviations (`abbreviation expansion` as compared to zsh abbr's `abbreviation=expansion`).
 
-To migrate from fish:
+In fish:
 
 ```shell
-fish
 abbr -s > file/to/save/fish/abbreviations/to
-zsh
-abbr [(--global|-g)] [SCOPE] import-fish file/to/save/fish/abbreviations/to
-# file is no longer needed, so feel free to
-# rm file/to/save/fish/abbreviations/to
 ```
 
-To migrate from zsh-abbr < 3:
+Then in zsh:
 
 ```shell
-zsh
-abbr [(--global|-g)] [SCOPE] ${HOME}/.config/zsh/universal-abbreviations
-# zsh-abbr > 2 no longer uses that file
-# If not customizing `ABBR_USER_ABBREVIATIONS_FILE=${HOME}/.config/zsh/universal-abbreviations` feel free to
-# rm ${HOME}/.config/zsh/universal-abbreviations
+abbr import-fish file/to/save/fish/abbreviations/to
+# file is no longer needed, so feel free to
+# rm file/to/save/fish/abbreviations/to
 ```
 
 Note that zsh-abbr does not lint the imported abbreviations. An effort is made to correctly wrap the expansion in single or double quotes, but it is possible that importing will add an abbreviation with a quotation mark problem in the expansion. It is up to the user to double check the result before taking further actions.
 
 Use `--dry-run` to see what would result, without making any actual changes.
 
-##### Git Aliases
+#### `import-git-aliases`
 
 ```shell
 abbr import-git-aliases [--dry-run] [--quiet]
@@ -375,71 +354,13 @@ Note that zsh-abbr does not lint the imported abbreviations. It is up to the use
 
 Use `--dry-run` to see what would result, without making any actual changes.
 
-#### List
-
-List all the abbreviations available in the current session. Regular abbreviations follow global abbreviations. Session abbreviations follow user abbreviations.
-
-Use the **--session** or **-S** scope flag to list only session abbreviations. Use the **--user** or **-U** scope flag to list only user abbreviations.
-
-Use the **--global** or **-g** type flag to list only global abbreviations. Use the **--regular** or **-r** type flag to list only regular abbreviations.
-
-Combine a scope flag and a type flag to further limit the output.
-
-##### Abbreviations
+#### `list`
 
 ```shell
-abbr (list-abbreviations | l) [(--session | -S) | (--user | -U)] [(--global | -g) | (--regular | -r)]
+abbr [list] [<SCOPE>] [<TYPE>]
 ```
 
-List the abbreviations only, like fish's `abbr -l`.
-
-```shell
-% abbr a=apple
-% abbr -g b=ball
-% abbr -S c=cat
-% abbr -S -g d=dog
-% abbr list-abbreviations
-a
-b
-c
-d
-% source ~/.zshrc
-% abbr list-abbreviations
-a
-b
-```
-
-##### Commands
-
-```shell
-abbr (list-commands | L) [(--session | -S) | (--user | -U)] [(--global | -g) | (--regular | -r)]
-```
-
-List as commands, like zsh's `alias -L`.
-
-```shell
-% abbr a=apple
-% abbr -g b=ball
-% abbr -S c=cat
-% abbr -S -g d=dog
-% abbr list-abbreviations
-abbr a="apple"
-abbr -g b="ball"
-abbr -S c="cat"
-abbr -S -g d="dog"
-% source ~/.zshrc
-% abbr list-abbreviations
-abbr a="apple"
-abbr -g b="ball"
-```
-
-##### Definitions
-
-```shell
-abbr [list-definitions] [(--session | -S) | (--user | -U)] [(--global | -g) | (--regular | -r)]
-```
-
-List as commands, like zsh's `alias`.
+List the abbreviations only, like fish's `abbr -l`. Regular abbreviations follow global abbreviations. Session abbreviations follow user abbreviations.
 
 ```shell
 % abbr a=apple
@@ -457,10 +378,58 @@ a="apple"
 b="ball"
 ```
 
-#### Rename
+#### `list-abbreviations`
 
 ```shell
-abbr (rename | R) [(--session | -S) | (--user | -U)] [(--global | -g) | (--regular | -r)] [--dry-run] [--quiet] OLD NEW
+abbr (list-abbreviations | l) [<SCOPE>] [<TYPE>]
+```
+
+List the abbreviations with their expansions, like zsh's `alias`. Regular abbreviations follow global abbreviations. Session abbreviations follow user abbreviations.
+
+```shell
+% abbr a=apple
+% abbr -g b=ball
+% abbr -S c=cat
+% abbr -S -g d=dog
+% abbr list-abbreviations
+a
+b
+c
+d
+% source ~/.zshrc
+% abbr list-abbreviations
+a
+b
+```
+
+#### `list-commands`
+
+```shell
+abbr (list-commands | L) [<SCOPE>] [<TYPE>]
+```
+
+List as commands suitable for export, like zsh's `alias -L`. Regular abbreviations follow global abbreviations. Session abbreviations follow user abbreviations.
+
+```shell
+% abbr a=apple
+% abbr -g b=ball
+% abbr -S c=cat
+% abbr -S -g d=dog
+% abbr list-abbreviations
+abbr a="apple"
+abbr -g b="ball"
+abbr -S c="cat"
+abbr -S -g d="dog"
+% source ~/.zshrc
+% abbr list-abbreviations
+abbr a="apple"
+abbr -g b="ball"
+```
+
+#### `rename`
+
+```shell
+abbr (rename | R) [<SCOPE>] [<TYPE>] [--dry-run] [--quiet] OLD NEW
 ```
 
 Rename an abbreviation.
@@ -480,7 +449,7 @@ Rename is scope- and type-specific. If you get a "no matching abbreviation" erro
 % gm[Space] # expands to git checkout master
 ```
 
-Use `--dry-run` to see what would result, without making any actual changes..
+Use `--dry-run` to see what would result, without making any actual changes.
 
 Abbreviations can also be manually renamed in the `ABBR_USER_ABBREVIATIONS_FILE`. See **Storage** below.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # zsh-abbr ![GitHub release (latest by date)](https://img.shields.io/github/v/release/olets/zsh-abbr)
 
-The zsh manager for auto-expanding abbreviations, inspired by fish shell.
+**abbr** is the zsh manager for auto-expanding abbreviations - text that when written in a terminal is replaced with other (typically longer) text. Inspired by fish shell.
 
-**abbr** manages abbreviations - user-defined words that are replaced with longer phrases after they are entered.
+For example, a frequently-run command like `git checkout` can be abbreviated to `gco` (or even `co` or `c` or anything else). Type <kbd>Space</kbd> after an abbreviation to expand it. Type <kbd>Enter</kbd> after an abbreviation to expand it and run the expansion. To prevent expansion, add <kbd>Ctrl</kbd> (<kbd>Ctrl</kbd><kbd>Space</kbd> / <kbd>Ctrl</kbd><kbd>Enter</kbd>) or add a delimiter like `;` after the abbreviation.
 
-For example, a frequently-run command like `git checkout` can be abbreviated to `gco` (or even `co` or `c` or anything else). After entering `gco` and pressing <kbd>Space</kbd>, the full text `git checkout` will appear in the command line. To prevent expansion, press <kbd>Ctrl</kbd><kbd>Space</kbd> in place of <kbd>Space</kbd>. Pressing <kbd>Enter</kbd> after an abbreviation will expand the abbreviation and accept the current line.
+Like zsh's `alias`, zsh-abbr supports "regular" (i.e. command-position) and "global" (anywhere on the line) abbreviations. Like fish's abbr, zsh-abbr supports interactive creation of persistent abbreviations that are immediately available in all terminal sessions and.
 
-Like zsh's `alias`, zsh-abbr supports "regular" (i.e. command-position) and global (anywhere on the line) abbreviations. Like fish abbr, zsh-abbr supports session-specific and cross-session abbreviations.
-
-Run `abbr help` (or `abbr h`) for documentation; if the package is installed with Homebrew, `man abbr` is also available.
+Run `abbr help` for documentation; if the package is installed with Homebrew, `man abbr` is also available.
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -126,32 +126,32 @@ Clone this repo and add `source path/to/zsh-abbr.zsh` to your `.zshrc`.
 ## Usage
 
 ```shell
-abbr [<SCOPE>] [<TYPE>] <OPTION> [<ARGS>]
+abbr [<SCOPE>] [<TYPE>] <COMMAND> [<ARGS>]
 ```
 
-Options which make changes can be passed `--dry-run`.
+Commands which make changes can be passed `--dry-run`.
 
-Options which have output can be passed `--quiet`.
+Commands which have output can be passed `--quiet`.
 
-`<OPTION> [<ARGS>]` must be last.
+`<COMMAND> [<ARGS>]` must be last.
 
-### Scope
+### Scopes
 
-A given abbreviation can be limited to the current zsh session (i.e. the current terminal) —these are called *session* abbreviations— or to all terminals —these are called *user* abbreviations. Select options take **scope** as an argument.
+A given abbreviation can be limited to the current zsh session (i.e. the current terminal) —these are called *session* abbreviations— or to all terminals —these are called *user* abbreviations. Select commands take **scope** as an argument.
 
 Newly added user abbreviations are available to all open sessions immediately.
 
 Default is user.
 
-### Type
+### Types
 
-Regular abbreviations match the word at the start of the command line, and global abbreviations match any word on the line. Select options take **type** as an argument.
+Regular abbreviations match the word at the start of the command line, and global abbreviations match any word on the line. Select commands take **type** as an argument.
 
 Default is regular.
 
-### Options
+### Commands
 
-zsh-abbr has options to add, rename, and erase abbreviations; to add abbreviations for every alias or Git alias; to list the available abbreviations with or without their expansions; and to create aliases from abbreviations.
+zsh-abbr has commands to add, rename, and erase abbreviations; to add abbreviations for every alias or Git alias; to list the available abbreviations with or without their expansions; and to create aliases from abbreviations.
 
 `abbr` with no arguments is shorthand for `abbr list`. `abbr ...` with arguments is shorthand for `abbr add ...`.
 
@@ -173,7 +173,7 @@ To add a global abbreviation, use the **--global** flag. Otherwise the new abbre
 % gcm[Enter] # expands and accepts git checkout master
 ```
 
-`add` is the default option, and does not need to be explicit:
+`add` is the default command, and does not need to be explicit:
 
 ```shell
 % abbr gco='git checkout'

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Run `abbr help` (or `abbr h`) for documentation; if the package is installed wit
 # Add and use an abbreviation
 % abbr gc="git checkout"
 % gc[Space] # space expands this to `git checkout `
-% abbr gcm="git checkout master"
-% gcm[Enter] # enter expands this to `git checkout master` and then accepts
-Switched to branch 'master'
-Your branch is up to date with 'origin/master'.
+% abbr gcm="git checkout main"
+% gcm[Enter] # enter expands this to `git checkout main` and then accepts
+Switched to branch 'main'
+Your branch is up to date with 'origin/main'.
 %
 
 # Abbreviations are immediately available to all current and future sessions
@@ -55,7 +55,7 @@ Your branch is up to date with 'origin/master'.
 # Rename an abbreviation
 % abbr -r gcm cm
 % gcm[Space] # does not expand
-% cm[Space] # expands to `git checkout master `
+% cm[Space] # expands to `git checkout main `
 
 # Make the switch from aliases
 % abbr import-aliases
@@ -168,9 +168,9 @@ To add a session abbreviation, use the **--session** or **-S** scope flag. Other
 To add a global abbreviation, use the **--global** flag. Otherwise the new abbreviation will be a command abbreviation.
 
 ```shell
-% abbr add gcm='git checkout master'
-% gcm[Space] # expands as git checkout master
-% gcm[Enter] # expands and accepts git checkout master
+% abbr add gcm='git checkout main'
+% gcm[Space] # expands as git checkout main
+% gcm[Enter] # expands and accepts git checkout main
 ```
 
 `add` is the default command, and does not need to be explicit:
@@ -221,9 +221,9 @@ Use the **--session** or **-S** scope flag to erase a session abbreviation. Othe
 Use the **--global** flag to erase a session abbreviation. Otherwise a cross-session abbreviation will be erased.
 
 ```shell
-% abbr gcm="git commit master"
-% gcm[Enter] # expands and accepts git commit master
-Switched to branch 'master'
+% abbr gcm="git checkout main"
+% gcm[Enter] # expands and accepts git checkout main
+Switched to branch 'main'
 % abbr -e gcm;[Enter] # or abbr -e gcm[Ctrl-Space][Enter]
 % gcm[Space|Enter] # normal
 ```
@@ -259,10 +259,10 @@ Use the **--global** or **-g** type flag to export only global abbreviations. Us
 Combine a scope flag and a type flag to further limit the output.
 
 ```shell
-% abbr gcm="git checkout master"
+% abbr gcm="git checkout main"
 % abbr -S g=git
 % abbr export-aliases
-alias gcm='git checkout master'
+alias gcm='git checkout main'
 % abbr export-aliases --session
 alias g='git'
 % abbr export-aliases ~/.zshrc
@@ -449,12 +449,12 @@ Use the **--global** flag to rename a global abbreviation. Otherwise a command a
 Rename is scope- and type-specific. If you get a "no matching abbreviation" error, make sure you added the right flags (list abbreviations if you are not sure).
 
 ```shell
-% abbr add gcm git checkout master
-% gcm[Space] # expands to git checkout master
+% abbr add gcm git checkout main
+% gcm[Space] # expands to git checkout main
 % gm[Space] # no expansion
 % abbr rename gcm[Ctrl-Space] gm
 % gcm[Space] # no expansion
-% gm[Space] # expands to git checkout master
+% gm[Space] # expands to git checkout main
 ```
 
 Use `--dry-run` to see what would result, without making any actual changes.
@@ -561,7 +561,7 @@ Thanks for your interest. Contributions are welcome!
 
 Check the [Issues](https://github.com/olets/zsh-abbr/issues) to see if your topic has been discussed before or if it is being worked on. You may also want to check the roadmap (see above). Discussing in an Issue before opening a Pull Request means future contributors only have to search in one place.
 
-This project loosely follows the [Angular commit message conventions](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit). This helps with searchability and with the changelog, which is generated automatically and touched up by hand only if necessary. Use the commit message format `<type>(<scope>): <subject>`, where `<type>` is **feat** for new or changed behavior, **fix** for fixes, **docs** for documentation, **style** for under the hood changes related to for example zshisms, **refactor** for other refactors, **test** for tests, or **chore** chore for general maintenance (this will be used primarily by maintainers not contributors, for example for version bumps). `<scope>` is more loosely defined. Look at the [commit history](https://github.com/olets/zsh-abbr/commits/master) for ideas.
+This project loosely follows the [Angular commit message conventions](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit). This helps with searchability and with the changelog, which is generated automatically and touched up by hand only if necessary. Use the commit message format `<type>(<scope>): <subject>`, where `<type>` is **feat** for new or changed behavior, **fix** for fixes, **docs** for documentation, **style** for under the hood changes related to for example zshisms, **refactor** for other refactors, **test** for tests, or **chore** chore for general maintenance (this will be used primarily by maintainers not contributors, for example for version bumps). `<scope>` is more loosely defined.
 
 Tests are in the `tests` directory. To run them, replace `zsh-abbr` with `zsh-abbr/tests` in .zshrc. For example, zinit users will run
 

--- a/README.md
+++ b/README.md
@@ -463,17 +463,17 @@ Abbreviations can also be manually renamed in the `ABBR_USER_ABBREVIATIONS_FILE`
 
 ### Configuration variables
 
+In addition to the following, setting `NO_COLOR` (regardless of its value) will disable color output. See https://no-color.org/.
+
 Variable | Type | Use | Default
 ---|---|---|---
-`ABBR_AUTOLOAD` | integer Boolean | Automatically accounting for updates to the user abbrevations file (see [Storage and manual editing](#storage-and-manual-editing)) | 1
-`ABBR_DEBUG` | integer Boolean | Print debugging messages | 0
-`ABBR_DEFAULT_BINDINGS` | integer Boolean | Add the default bindings (see [Bindings](#bindings)) | 1
-`ABBR_DRY_RUN` | integer Boolean | Use dry run mode without passing `--dry-run` | 0
-`ABBR_FORCE` | integer Boolean | Use force mode without passing `--force` (see [`add`](#add)) | 0
-`ABBR_QUIET` | integer Boolean | Use quiet mode without passing `--quiet` | 0
+`ABBR_AUTOLOAD` | integer Boolean | If non-zero, automatically account for updates to the user abbrevations file (see [Storage and manual editing](#storage-and-manual-editing)) | 1
+`ABBR_DEBUG` | integer Boolean | If non-zero, print debugging messages | 0
+`ABBR_DEFAULT_BINDINGS` | integer Boolean | If non-zero, add the default bindings (see [Bindings](#bindings)) | 1
+`ABBR_DRY_RUN` | integer Boolean | If non-zero, use dry run mode without passing `--dry-run` | 0
+`ABBR_FORCE` | integer Boolean | If non-zero, use force mode without passing `--force` (see [`add`](#add)) | 0
+`ABBR_QUIET` | integer Boolean | If non-zero, use quiet mode without passing `--quiet` | 0
 `ABBR_USER_ABBREVIATIONS_FILE` | path string | The location of the user abbreviation file (see [Storage and manual editing](#storage-and-manual-editing)) | `$HOME/.config/zsh/abbreviations`
-
-In addition, setting `NO_COLOR` (regardless of its value) will disable color output. See https://no-color.org/.
 
 ### Storage and manual editing
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Switched to branch 'main'
 
 User abbreviations can also be manually erased from the `ABBR_USER_ABBREVIATIONS_FILE`. See **Storage** below.
 
-a `expand`
+#### `expand`
 
 ```shell
 abbr (expand | x) ABBREVIATION

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Run `abbr help` for documentation; if the package is installed with Homebrew, `m
 1. [Installation](#installation)
 1. [Usage](#usage)
 1. [Advanced](#advanced)
+1. [Performance](#performance)
 1. [Uninstalling](#uninstalling)
 1. [Changelog](#changelog)
 1. [Roadmap](#roadmap)
@@ -74,7 +75,7 @@ and follow the post-install instructions logged to the terminal.
 
 ### Plugin
 
-Or install zsh-abbr with your favorite plugin manager:
+Or install zsh-abbr with your favorite plugin manager (if you're new to zsh plugin management, at this writing zinit is most performant).
 
 - **[antibody](https://getantibody.github.io/)**: Add `olets/zsh-abbr` to your plugins file. If you use static loading, reload plugins.
 
@@ -98,8 +99,14 @@ Or install zsh-abbr with your favorite plugin manager:
 
 - **[zinit](https://github.com/zdharma/zinit)** (formerly **zplugin**): add this to your `.zshrc`:
   ```shell
+  zinit light olets/zsh-abbr
+  ```
+
+  If you notice `zsh-abbr` significantly affecting the startup time of new terminals, delay loading zsh-abbr until after shell initialization is finished. Not recommended as the default so that abbreviatons are available the moment you are able to type. See also [Performance](#performance).
+
+  ```shell
   zinit ice wait lucid
-  zinit light olets/zsh-abbr # or `load` instead of `light` to enable zinit reporting
+  zinit light olets/zsh-abbr
   ```
 
 - **[zplug](https://github.com/zplug/zplug)**: add `zplug "olets/zsh-abbr"` to your `.zshrc`.
@@ -107,7 +114,6 @@ Or install zsh-abbr with your favorite plugin manager:
 If you prefer to manage the package with Homebrew but load it with a plugin manager, run the Homebrew installation command and then point the plugin manager to the file Homebrew logs to the console. For example with zinit:
 
 ```shell
-zinit ice wait lucid
 zinit light /usr/local/share/zsh-abbr
 ```
 
@@ -531,6 +537,14 @@ bindkey "^A" _abbr_expand_space
 # load zsh-abbr
 ```
 
+## Performance
+
+Snapshot with macOS 10.15 on early-2015 MacBook Pro (2.9 GHz Intel Core i5, 16 GB 1867 MHz DDR3), zsh 5.8, zinit 3.1, iTerm2 3.3.12. Profiled with `zprof`.
+
+`zinit light olets/zsh-abbr` adds roughly 120ms to the time it takes a new terminal session to load; each user abbreviation adds roughly another 1ms.
+
+zsh-abbr will not affect time between prompts.
+
 ## Uninstalling
 
 Delete the session data storage directory
@@ -577,14 +591,12 @@ This project loosely follows the [Angular commit message conventions](https://do
 Tests are in the `tests` directory. To run them, replace `zsh-abbr` with `zsh-abbr/tests` in .zshrc. For example, zinit users will run
 
 ```shell
-zinit ice lucid
 zinit light olets/zsh-abbr/tests
 ```
 
 in place of
 
 ```shell
-zinit ice lucid
 zinit light olets/zsh-abbr
 ```
 

--- a/README.md
+++ b/README.md
@@ -473,7 +473,8 @@ Variable | Type | Use | Default
 `ABBR_DRY_RUN` | integer Boolean | If non-zero, use dry run mode without passing `--dry-run` | 0
 `ABBR_FORCE` | integer Boolean | If non-zero, use force mode without passing `--force` (see [`add`](#add)) | 0
 `ABBR_QUIET` | integer Boolean | If non-zero, use quiet mode without passing `--quiet` | 0
-`ABBR_USER_ABBREVIATIONS_FILE` | path string | The location of the user abbreviation file (see [Storage and manual editing](#storage-and-manual-editing)) | `$HOME/.config/zsh/abbreviations`
+`ABBR_TMPDIR` | String | Path to the directory temporary files are stored in. _Ends in `/`_ | `${TMPDIR:-/tmp/}zsh-abbr/}`
+`ABBR_USER_ABBREVIATIONS_FILE` | String | Path to the file user abbreviation are stored in (see [Storage and manual editing](#storage-and-manual-editing)) | `$HOME/.config/zsh/abbreviations`
 
 ### Exported variables
 
@@ -535,7 +536,7 @@ bindkey "^A" _abbr_expand_space
 Delete the session data storage directory
 
 ```shell
-% rm -rf ${TMPDIR:-/tmp/}zsh-abbr
+% rm -rf $ABBR_TMPDIR
 ```
 
 To delete the user abbreviations file,

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Default is regular.
 
 zsh-abbr has options to add, rename, and erase abbreviations; to add abbreviations for every alias or Git alias; to list the available abbreviations with or without their expansions; and to create aliases from abbreviations.
 
-`abbr` with no arguments is shorthand for `abbr list-commands`. `abbr ...` with arguments is shorthand for `abbr add ...`.
+`abbr` with no arguments is shorthand for `abbr list`. `abbr ...` with arguments is shorthand for `abbr add ...`.
 
 #### `add`
 
@@ -360,22 +360,30 @@ Use `--dry-run` to see what would result, without making any actual changes.
 abbr [list] [<SCOPE>] [<TYPE>]
 ```
 
-List the abbreviations only, like fish's `abbr -l`. Regular abbreviations follow global abbreviations. Session abbreviations follow user abbreviations.
+List the abbreviations with their expansions, like zsh's `alias`. Regular abbreviations follow global abbreviations. Session abbreviations follow user abbreviations.
 
 ```shell
 % abbr a=apple
 % abbr -g b=ball
 % abbr -S c=cat
 % abbr -S -g d=dog
-% abbr # or abbr list-abbreviations
+% abbr list
 a="apple"
 b="ball"
 c="cat"
 d="dog"
 % source ~/.zshrc
-% abbr # or abbr list-abbreviations
+% abbr list
 a="apple"
 b="ball"
+```
+
+`list` is the default when no additional arguments are passed; it does not need to be made explicit:
+
+```shell
+% abbr a=apple
+% abbr
+a="apple"
 ```
 
 #### `list-abbreviations`
@@ -384,7 +392,7 @@ b="ball"
 abbr (list-abbreviations | l) [<SCOPE>] [<TYPE>]
 ```
 
-List the abbreviations with their expansions, like zsh's `alias`. Regular abbreviations follow global abbreviations. Session abbreviations follow user abbreviations.
+List the abbreviations only, like fish's `abbr -l`. Regular abbreviations follow global abbreviations. Session abbreviations follow user abbreviations.
 
 ```shell
 % abbr a=apple

--- a/README.md
+++ b/README.md
@@ -75,57 +75,21 @@ and follow the post-install instructions logged to the terminal.
 
 ### Plugin
 
-Or install zsh-abbr with your favorite plugin manager (if you're new to zsh plugin management, at this writing zinit is most performant).
+You can install zsh-abbr with a zsh plugin manager. Each has their own way of doing things. See your package manager's documentation or the [zsh plugin manager plugin installation procedures gist](https://gist.github.com/olets/06009589d7887617e061481e22cf5a4a). If you're new to zsh plugin management, at this writing zinit is a good choice for its popularity, frequent updates, and great performance.
 
-- **[antibody](https://getantibody.github.io/)**: Add `olets/zsh-abbr` to your plugins file. If you use static loading, reload plugins.
-
-- **[Antigen](https://github.com/zsh-users/antigen)**: Add `antigen bundle olets/zsh-abbr` to your `.zshrc`.
-
-- **[Oh-My-Zsh](https://github.com/robbyrussell/oh-my-zsh)**:
-
-  - Clone to OMZ's plugins' directory:
-
-    ```shell
-    git clone https://github.com/olets/zsh-abbr.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-abbr
-    ```
-
-  - Add to the OMZ plugins array in your `.zshrc`:
-
-    ```shell
-    plugins=( [plugins...] zsh-abbr)
-    ```
-
-- **[zgen](https://github.com/tarjoilija/zgen)**: add `zgen load olets/zsh-abbr` to your `.zshrc`.
-
-- **[zinit](https://github.com/zdharma/zinit)** (formerly **zplugin**): add this to your `.zshrc`:
-  ```shell
-  zinit light olets/zsh-abbr
-  ```
-
-  If you notice `zsh-abbr` significantly affecting the startup time of new terminals, delay loading zsh-abbr until after shell initialization is finished. Not recommended as the default so that abbreviatons are available the moment you are able to type. See also [Performance](#performance).
-
-  ```shell
-  zinit ice wait lucid
-  zinit light olets/zsh-abbr
-  ```
-
-- **[zplug](https://github.com/zplug/zplug)**: add `zplug "olets/zsh-abbr"` to your `.zshrc`.
-
-If you prefer to manage the package with Homebrew but load it with a plugin manager, run the Homebrew installation command and then point the plugin manager to the file Homebrew logs to the console. For example with zinit:
+After adding the plugin to the manager, restart zsh:
 
 ```shell
-zinit light /usr/local/share/zsh-abbr
-```
-
-If running `abbr` gives an error "zsh: permission denied: abbr", reload zsh:
-
-```shell
-% source ~/.zshrc
+exec zsh
 ```
 
 ### Manual
 
-Clone this repo and add `source path/to/zsh-abbr.zsh` to your `.zshrc`.
+Clone this repo and add `source path/to/zsh-abbr.zsh` to your `.zshrc`. Then restart zsh:
+
+```shell
+exec zsh
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -479,8 +479,12 @@ Variable | Type | Use | Default
 `ABBR_DRY_RUN` | integer | If non-zero, use dry run mode without passing `--dry-run` | 0
 `ABBR_FORCE` | integer | If non-zero, use force mode without passing `--force` (see [`add`](#add)) | 0
 `ABBR_QUIET` | integer | If non-zero, use quiet mode without passing `--quiet` | 0
-`ABBR_TMPDIR` | String | Path to the directory temporary files are stored in. _Ends in `/`_ | `${TMPDIR:-/tmp/}zsh-abbr/}`
-`ABBR_USER_ABBREVIATIONS_FILE` | String | Path to the file user abbreviation are stored in (see [Storage and manual editing](#storage-and-manual-editing)) | `$HOME/.config/zsh/abbreviations`
+`ABBR_TMPDIR` | String | Path to the directory temporary files are stored in. _Ends in `/`_ | `${TMPDIR:-/tmp/}zsh-abbr/}` *
+`ABBR_USER_ABBREVIATIONS_FILE` | String | Path to the file user abbreviation are stored in (see [Storage and manual editing](#storage-and-manual-editing)) | `$HOME/.config/zsh/abbreviations` **
+
+\* If changing this, you may want to delete the default directory.
+
+\** If changing this, you may want to delete the default file.
 
 ### Exported variables
 
@@ -496,25 +500,13 @@ Each element in `ABBR_GLOBAL_SESSION_ABBREVIATIONS`, `ABBR_GLOBAL_USER_ABBREVIAT
 
 ### Storage and manual editing
 
-User abbreviations live in a plain text file which you can edit directly, share, keep in version control, etc. Abbreviations in this file are loaded when each new session is opened; non-`abbr` commands will be ignored excised from the file.
+User abbreviations live in a plain text file which you can edit directly, share, keep in version control, etc. Abbreviations in this file are loaded when each new session is opened; non-`abbr` commands will be ignored and then excised from the file.
 
-When zsh-abbr updates the user abbreviations storage file, the lines are alphabetized and global user abbreviations are moved to the top of the file.
+zsh-abbr automatically keeps the user abbreviations storage file alphabetized, with all global user abbreviations before the first regular user abbreviation.
 
-Run `abbr load` to load changes made directly to the user abbreviation file (that is, changes made with a text editor or `echo` as opposed to changes made with `abbr (add|erase|import…|rename)`) into the current session.
+Every time an `abbr` command is run, the session's updates its user abbreviatons with the latest from the user abbreviations file. This should add no appreciable time, but you prefer it can be turned off by setting `ABBR_AUTOLOAD=0`.
 
-`abbr load` is run automatically at the start of every other `abbr` command (`abbr (add|erase|import…|rename)`, not every expansion). This should add no appreciable time (clocked at 0.02ms per saved abbreviation), but it can be turned off by setting `ABBR_AUTOLOAD=0`.
-
-The user abbreviations storage file's default location is `${HOME}/.config/zsh/abbreviations`. Customize this by setting the `ABBR_USER_ABBREVIATIONS_FILE` variable in your `.zshrc` before loading zsh-abbr:
-
-```shell
-% cat ~/.zshrc
-# -- snip --
-ABBR_USER_ABBREVIATIONS_FILE="path/to/my/user/abbreviations"
-# -- snip --
-# load zsh-abbr
-```
-
-The default file is created the first time zsh-abbr is run. If you customize the path, you may want to delete the default file or even the default zsh-abbr config directory.
+To refresh the user abbreviations from the user abbreviation, run `abbr load` (or any other `abbr` command).
 
 ### Bindings
 
@@ -526,7 +518,7 @@ By default
 
 (In incremental search mode, <kbd>Space</kbd> is a normal space and <kbd>Ctrl</kbd><kbd>Space</kbd> expands abbreviations.)
 
-If you want to set your own bindings, set `ABBR_DEFAULT_BINDINGS` to `0` in your `.zshrc` before loading zsh-abbr. In the following example, expansion is bound to <kbd>Ctrl</kbd><kbd>a</kbd>:
+Custom bindings can be set in your `.zshrc` before loading zsh-abbr. In the following example, expansion is bound to <kbd>Ctrl</kbd><kbd>a</kbd>:
 
 ```shell
 % cat ~/.zshrc
@@ -553,7 +545,7 @@ Delete the session data storage directory
 % rm -rf $ABBR_TMPDIR
 ```
 
-To delete the user abbreviations file,
+If you want to delete the user abbreviations file,
 
 ```shell
 % rm $ABBR_USER_ABBREVIATIONS_FILE

--- a/README.md
+++ b/README.md
@@ -475,6 +475,18 @@ Variable | Type | Use | Default
 `ABBR_QUIET` | integer Boolean | If non-zero, use quiet mode without passing `--quiet` | 0
 `ABBR_USER_ABBREVIATIONS_FILE` | path string | The location of the user abbreviation file (see [Storage and manual editing](#storage-and-manual-editing)) | `$HOME/.config/zsh/abbreviations`
 
+### Exported variables
+
+Variable | Type | Value
+---|---|---
+`ABBR_GLOBAL_SESSION_ABBREVIATIONS` | Associative array | The global session abbreviations
+`ABBR_GLOBAL_USER_ABBREVIATIONS` | Associative array | The global user abbreviations
+`ABBR_LOADING_USER_ABBREVIATIONS` | Integer Boolean | Set to `1` when the interactive shell is refreshing its list of user abbreviations, otherwise not set
+`ABBR_REGULAR_SESSION_ABBREVIATIONS` | Associative array | The regular session abbreviations
+`ABBR_REGULAR_USER_ABBREVIATIONS` | Associative array | The regular user abbreviations
+
+Each element in abbreviations associative arrays has the form `ABBREVIATION=EXPANSION`, and the expansion value is quoted. Scripters will probably want to remove one level of quotes, using the [Q modifier](http://zsh.sourceforge.net/Doc/Release/Expansion.html#Modifiers) (e.g. `for v in ${(Qv)ABBR_REGULAR_USER_ABBREVIATIONS}...`)
+
 ### Storage and manual editing
 
 User abbreviations live in a plain text file which you can edit directly, share, keep in version control, etc. Abbreviations in this file are loaded when each new session is opened; non-`abbr` commands will be ignored excised from the file.

--- a/README.md
+++ b/README.md
@@ -159,311 +159,311 @@ zsh-abbr has commands to add, rename, and erase abbreviations; to add abbreviati
 
 `abbr` with no arguments is shorthand for `abbr list`. `abbr ...` with arguments is shorthand for `abbr add ...`.
 
-#### `add`
+- **`add`**
 
-```shell
-abbr [(add | -a)] [<SCOPE>] [<TYPE>] [--dry-run] [--quiet] [--force] ABBREVIATION=EXPANSION
-```
+  ```shell
+  abbr [(add | -a)] [<SCOPE>] [<TYPE>] [--dry-run] [--quiet] [--force] ABBREVIATION=EXPANSION
+  ```
 
-Add a new abbreviation.
+  Add a new abbreviation.
 
-To add a session abbreviation, use the **--session** or **-S** scope flag. Otherwise, or if the **--user** or **-U** scope flag is used, the new abbreviation will be available to all sessions.
+  To add a session abbreviation, use the **--session** or **-S** scope flag. Otherwise, or if the **--user** or **-U** scope flag is used, the new abbreviation will be available to all sessions.
 
-To add a global abbreviation, use the **--global** flag. Otherwise the new abbreviation will be a command abbreviation.
+  To add a global abbreviation, use the **--global** flag. Otherwise the new abbreviation will be a command abbreviation.
 
-```shell
-% abbr add gcm='git checkout main'
-% gcm[Space] # expands as git checkout main
-% gcm[Enter] # expands and accepts git checkout main
-```
+  ```shell
+  % abbr add gcm='git checkout main'
+  % gcm[Space] # expands as git checkout main
+  % gcm[Enter] # expands and accepts git checkout main
+  ```
 
-`add` is the default command, and does not need to be explicit:
+  `add` is the default command, and does not need to be explicit:
 
-```shell
-% abbr gco='git checkout'
-% gco[Space] # expands as git checkout
-% gco[Enter] # expands and accepts git checkout
-```
+  ```shell
+  % abbr gco='git checkout'
+  % gco[Space] # expands as git checkout
+  % gco[Enter] # expands and accepts git checkout
+  ```
 
-The ABBREVIATION must be only one word long.
+  The ABBREVIATION must be only one word long.
 
-As with aliases, to include whitespace, quotation marks, or other special characters like `;`, `|`, or `&` in the EXPANSION, quote the EXPANSION or `\`-escape the characters as necessary.
+  As with aliases, to include whitespace, quotation marks, or other special characters like `;`, `|`, or `&` in the EXPANSION, quote the EXPANSION or `\`-escape the characters as necessary.
 
-```shell
-abbr a=b\;c  # allowed
-abbr a="b|c" # allowed
-```
+  ```shell
+  abbr a=b\;c  # allowed
+  abbr a="b|c" # allowed
+  ```
 
-User-scope abbreviations can also be manually to the user abbreviations file. See **Storage** below.
+  User-scope abbreviations can also be manually to the user abbreviations file. See **Storage** below.
 
-The session regular, session global, user regular, and user global abbreviation sets are independent. If you wanted, you could have more than one abbreviation with the same ABBREVIATION. Order of precedence is "session command > user command > session global > user global".
+  The session regular, session global, user regular, and user global abbreviation sets are independent. If you wanted, you could have more than one abbreviation with the same ABBREVIATION. Order of precedence is "session command > user command > session global > user global".
 
-Use `--dry-run` to see what would result, without making any actual changes.
+  Use `--dry-run` to see what would result, without making any actual changes.
 
-Will error rather than overwrite an existing abbreviation.
+  Will error rather than overwrite an existing abbreviation.
 
-Will warn if the abbreviation would replace an existing command. To add in spite of the warning, use `--force`.
+  Will warn if the abbreviation would replace an existing command. To add in spite of the warning, use `--force`.
 
-#### `clear-session`
+- **`clear-session`**
 
-```shell
-abbr (clear-session | c)
-```
+  ```shell
+  abbr (clear-session | c)
+  ```
 
-Erase all session abbreviations.
+  Erase all session abbreviations.
 
-#### `erase`
+- **`erase`**
 
-```shell
-abbr (erase | e) [<SCOPE>] [<TYPE>] [--dry-run] [--quiet] ABBREVIATION
-```
+  ```shell
+  abbr (erase | e) [<SCOPE>] [<TYPE>] [--dry-run] [--quiet] ABBREVIATION
+  ```
 
-Erase an abbreviation.
+  Erase an abbreviation.
 
-Use the **--session** or **-S** scope flag to erase a session abbreviation. Otherwise, or if the **--user** or **-U** scope flag is used, a cross-session abbreviation will be erased.
+  Use the **--session** or **-S** scope flag to erase a session abbreviation. Otherwise, or if the **--user** or **-U** scope flag is used, a cross-session abbreviation will be erased.
 
-Use the **--global** flag to erase a session abbreviation. Otherwise a cross-session abbreviation will be erased.
+  Use the **--global** flag to erase a session abbreviation. Otherwise a cross-session abbreviation will be erased.
 
-```shell
-% abbr gcm="git checkout main"
-% gcm[Enter] # expands and accepts git checkout main
-Switched to branch 'main'
-% abbr -e gcm;[Enter] # or abbr -e gcm[Ctrl-Space][Enter]
-% gcm[Space|Enter] # normal
-```
+  ```shell
+  % abbr gcm="git checkout main"
+  % gcm[Enter] # expands and accepts git checkout main
+  Switched to branch 'main'
+  % abbr -e gcm;[Enter] # or abbr -e gcm[Ctrl-Space][Enter]
+  % gcm[Space|Enter] # normal
+  ```
 
-User abbreviations can also be manually erased from the `ABBR_USER_ABBREVIATIONS_FILE`. See **Storage** below.
+  User abbreviations can also be manually erased from the `ABBR_USER_ABBREVIATIONS_FILE`. See **Storage** below.
 
-#### `expand`
+- **`expand`**
 
-```shell
-abbr (expand | x) ABBREVIATION
-```
+  ```shell
+  abbr (expand | x) ABBREVIATION
+  ```
 
-Output the ABBREVIATION's EXPANSION.
+  Output the ABBREVIATION's EXPANSION.
 
-```shell
-% abbr gc="git checkout"
-% abbr -x gc; # or `abbr -x gc[Ctrl-Space][Enter]`
-git checkout
-```
+  ```shell
+  % abbr gc="git checkout"
+  % abbr -x gc; # or `abbr -x gc[Ctrl-Space][Enter]`
+  git checkout
+  ```
 
-#### `export-aliases`
+- **`export-aliases`**
 
-```shell
-abbr export-aliases [<SCOPE>] [<TYPE>] [DESTINATION]
-```
+  ```shell
+  abbr export-aliases [<SCOPE>] [<TYPE>] [DESTINATION]
+  ```
 
-Export abbreviations as alias commands. Regular abbreviations follow global abbreviations. Session abbreviations follow user abbreviations.
+  Export abbreviations as alias commands. Regular abbreviations follow global abbreviations. Session abbreviations follow user abbreviations.
 
-Use the **--session** or **-S** scope flag to export only session abbreviations. Use the **--user** or **-U** scope flag to export only user abbreviations.
+  Use the **--session** or **-S** scope flag to export only session abbreviations. Use the **--user** or **-U** scope flag to export only user abbreviations.
 
-Use the **--global** or **-g** type flag to export only global abbreviations. Use the **--regular** or **-r** type flag to export only regular abbreviations.
+  Use the **--global** or **-g** type flag to export only global abbreviations. Use the **--regular** or **-r** type flag to export only regular abbreviations.
 
-Combine a scope flag and a type flag to further limit the output.
+  Combine a scope flag and a type flag to further limit the output.
 
-```shell
-% abbr gcm="git checkout main"
-% abbr -S g=git
-% abbr export-aliases
-alias gcm='git checkout main'
-% abbr export-aliases --session
-alias g='git'
-% abbr export-aliases ~/.zshrc
-% cat ~/.zshrc
-# -- snip --
-alias g='git'
-```
+  ```shell
+  % abbr gcm="git checkout main"
+  % abbr -S g=git
+  % abbr export-aliases
+  alias gcm='git checkout main'
+  % abbr export-aliases --session
+  alias g='git'
+  % abbr export-aliases ~/.zshrc
+  % cat ~/.zshrc
+  # -- snip --
+  alias g='git'
+  ```
 
-#### `import-aliases`
+- **`import-aliases`**
 
-```shell
-abbr import-aliases [<type>] [--dry-run] [--quiet]
-```
+  ```shell
+  abbr import-aliases [<type>] [--dry-run] [--quiet]
+  ```
 
-Add regular abbreviations for every regular alias in the session, and global abbreviations for every global alias in the session.
+  Add regular abbreviations for every regular alias in the session, and global abbreviations for every global alias in the session.
 
-```shell
-% cat ~/.zshrc
-# --snip--
-alias -S d='bin/deploy'
-# --snip--
+  ```shell
+  % cat ~/.zshrc
+  # --snip--
+  alias -S d='bin/deploy'
+  # --snip--
 
-% abbr import-aliases
-% d[Space] # expands to bin/deploy
-```
+  % abbr import-aliases
+  % d[Space] # expands to bin/deploy
+  ```
 
-Note that zsh-abbr does not lint the imported abbreviations. An effort is made to correctly wrap the expansion in single or double quotes, but it is possible that importing will add an abbreviation with a quotation mark problem in the expansion. It is up to the user to double check the result before taking further actions.
+  Note that zsh-abbr does not lint the imported abbreviations. An effort is made to correctly wrap the expansion in single or double quotes, but it is possible that importing will add an abbreviation with a quotation mark problem in the expansion. It is up to the user to double check the result before taking further actions.
 
-Use `--dry-run` to see what would result, without making any actual changes.
+  Use `--dry-run` to see what would result, without making any actual changes.
 
-#### `import-fish`
+- **`import-fish`**
 
-```shell
-abbr import-fish [<SCOPE>] FILE [--dry-run] [--quiet]
-```
+  ```shell
+  abbr import-fish [<SCOPE>] FILE [--dry-run] [--quiet]
+  ```
 
-Import fish abbr-syntax abbreviations (`abbreviation expansion` as compared to zsh abbr's `abbreviation=expansion`).
+  Import fish abbr-syntax abbreviations (`abbreviation expansion` as compared to zsh abbr's `abbreviation=expansion`).
 
-In fish:
+  In fish:
 
-```shell
-abbr -s > file/to/save/fish/abbreviations/to
-```
+  ```shell
+  abbr -s > file/to/save/fish/abbreviations/to
+  ```
 
-Then in zsh:
-
-```shell
-abbr import-fish file/to/save/fish/abbreviations/to
-# file is no longer needed, so feel free to
-# rm file/to/save/fish/abbreviations/to
-```
+  Then in zsh:
+
+  ```shell
+  abbr import-fish file/to/save/fish/abbreviations/to
+  # file is no longer needed, so feel free to
+  # rm file/to/save/fish/abbreviations/to
+  ```
 
-Note that zsh-abbr does not lint the imported abbreviations. An effort is made to correctly wrap the expansion in single or double quotes, but it is possible that importing will add an abbreviation with a quotation mark problem in the expansion. It is up to the user to double check the result before taking further actions.
+  Note that zsh-abbr does not lint the imported abbreviations. An effort is made to correctly wrap the expansion in single or double quotes, but it is possible that importing will add an abbreviation with a quotation mark problem in the expansion. It is up to the user to double check the result before taking further actions.
 
-Use `--dry-run` to see what would result, without making any actual changes.
+  Use `--dry-run` to see what would result, without making any actual changes.
 
-#### `import-git-aliases`
+- **`import-git-aliases`**
 
-```shell
-abbr import-git-aliases [--dry-run] [--quiet]
-```
-
-Add two abbreviations for every Git alias available in the current session: a global abbreviation where the WORD is prefixed with `g`, and a command abbreviation. For both the EXPANSION is prefixed with `git[Space]`.
-
-Use the **--session**  or **-S** scope flag to create session abbreviations. Otherwise, or if the **--user** or **-U** scope flag is used, the Git abbreviations will be user.
-
-```shell
-% git config alias.co checkout
-
-# session
-% abbr import-git-aliases -S
-% gco[Space] # git checkout
-% echo gco[Space] # echo git checkout
-% co[Space] # git checkout
-% echo co[Space] # echo co
-% source ~/.zshrc
-% gco[Space] # gco
-
-# user
-% abbr import-git-aliases
-% gco[Space] # git checkout
-% source ~/.zshrc
-% gco[Space] # git checkout
-```
+  ```shell
+  abbr import-git-aliases [--dry-run] [--quiet]
+  ```
+
+  Add two abbreviations for every Git alias available in the current session: a global abbreviation where the WORD is prefixed with `g`, and a command abbreviation. For both the EXPANSION is prefixed with `git[Space]`.
+
+  Use the **--session**  or **-S** scope flag to create session abbreviations. Otherwise, or if the **--user** or **-U** scope flag is used, the Git abbreviations will be user.
+
+  ```shell
+  % git config alias.co checkout
+
+  # session
+  % abbr import-git-aliases -S
+  % gco[Space] # git checkout
+  % echo gco[Space] # echo git checkout
+  % co[Space] # git checkout
+  % echo co[Space] # echo co
+  % source ~/.zshrc
+  % gco[Space] # gco
+
+  # user
+  % abbr import-git-aliases
+  % gco[Space] # git checkout
+  % source ~/.zshrc
+  % gco[Space] # git checkout
+  ```
 
-Note for users migrating from Oh-My-Zsh: [OMZ's Git aliases are shell aliases](https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/git/git.plugin.zsh), not aliases in the Git config. To add abbreviations for them, use **import-aliases**.
+  Note for users migrating from Oh-My-Zsh: [OMZ's Git aliases are shell aliases](https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/git/git.plugin.zsh), not aliases in the Git config. To add abbreviations for them, use **import-aliases**.
 
-Note that zsh-abbr does not lint the imported abbreviations. It is up to the user to double check the result before taking further actions.
+  Note that zsh-abbr does not lint the imported abbreviations. It is up to the user to double check the result before taking further actions.
 
-Use `--dry-run` to see what would result, without making any actual changes.
-
-#### `list`
-
-```shell
-abbr [list] [<SCOPE>] [<TYPE>]
-```
+  Use `--dry-run` to see what would result, without making any actual changes.
+
+- **`list`**
+
+  ```shell
+  abbr [list] [<SCOPE>] [<TYPE>]
+  ```
 
-List the abbreviations with their expansions, like zsh's `alias`. Regular abbreviations follow global abbreviations. Session abbreviations follow user abbreviations.
-
-```shell
-% abbr a=apple
-% abbr -g b=ball
-% abbr -S c=cat
-% abbr -S -g d=dog
-% abbr list
-a="apple"
-b="ball"
-c="cat"
-d="dog"
-% source ~/.zshrc
-% abbr list
-a="apple"
-b="ball"
-```
-
-`list` is the default when no additional arguments are passed; it does not need to be made explicit:
-
-```shell
-% abbr a=apple
-% abbr
-a="apple"
-```
-
-#### `list-abbreviations`
-
-```shell
-abbr (list-abbreviations | l) [<SCOPE>] [<TYPE>]
-```
-
-List the abbreviations only, like fish's `abbr -l`. Regular abbreviations follow global abbreviations. Session abbreviations follow user abbreviations.
-
-```shell
-% abbr a=apple
-% abbr -g b=ball
-% abbr -S c=cat
-% abbr -S -g d=dog
-% abbr list-abbreviations
-a
-b
-c
-d
-% source ~/.zshrc
-% abbr list-abbreviations
-a
-b
-```
-
-#### `list-commands`
-
-```shell
-abbr (list-commands | L) [<SCOPE>] [<TYPE>]
-```
-
-List as commands suitable for export, like zsh's `alias -L`. Regular abbreviations follow global abbreviations. Session abbreviations follow user abbreviations.
-
-```shell
-% abbr a=apple
-% abbr -g b=ball
-% abbr -S c=cat
-% abbr -S -g d=dog
-% abbr list-abbreviations
-abbr a="apple"
-abbr -g b="ball"
-abbr -S c="cat"
-abbr -S -g d="dog"
-% source ~/.zshrc
-% abbr list-abbreviations
-abbr a="apple"
-abbr -g b="ball"
-```
-
-#### `rename`
-
-```shell
-abbr (rename | R) [<SCOPE>] [<TYPE>] [--dry-run] [--quiet] OLD NEW
-```
-
-Rename an abbreviation.
-
-Use the **--session** or **-S** scope flag to rename a session abbreviation. Otherwise, or if the **--user** or **-U** scope flag is used, a cross-session abbreviation will be renamed.
-
-Use the **--global** flag to rename a global abbreviation. Otherwise a command abbreviation will be renamed.
-
-Rename is scope- and type-specific. If you get a "no matching abbreviation" error, make sure you added the right flags (list abbreviations if you are not sure).
-
-```shell
-% abbr add gcm git checkout main
-% gcm[Space] # expands to git checkout main
-% gm[Space] # no expansion
-% abbr rename gcm[Ctrl-Space] gm
-% gcm[Space] # no expansion
-% gm[Space] # expands to git checkout main
-```
-
-Use `--dry-run` to see what would result, without making any actual changes.
-
-Abbreviations can also be manually renamed in the `ABBR_USER_ABBREVIATIONS_FILE`. See **Storage** below.
+  List the abbreviations with their expansions, like zsh's `alias`. Regular abbreviations follow global abbreviations. Session abbreviations follow user abbreviations.
+
+  ```shell
+  % abbr a=apple
+  % abbr -g b=ball
+  % abbr -S c=cat
+  % abbr -S -g d=dog
+  % abbr list
+  a="apple"
+  b="ball"
+  c="cat"
+  d="dog"
+  % source ~/.zshrc
+  % abbr list
+  a="apple"
+  b="ball"
+  ```
+
+  `list` is the default when no additional arguments are passed; it does not need to be made explicit:
+
+  ```shell
+  % abbr a=apple
+  % abbr
+  a="apple"
+  ```
+
+- **`list-abbreviations`**
+
+  ```shell
+  abbr (list-abbreviations | l) [<SCOPE>] [<TYPE>]
+  ```
+
+  List the abbreviations only, like fish's `abbr -l`. Regular abbreviations follow global abbreviations. Session abbreviations follow user abbreviations.
+
+  ```shell
+  % abbr a=apple
+  % abbr -g b=ball
+  % abbr -S c=cat
+  % abbr -S -g d=dog
+  % abbr list-abbreviations
+  a
+  b
+  c
+  d
+  % source ~/.zshrc
+  % abbr list-abbreviations
+  a
+  b
+  ```
+
+- **`list-commands`**
+
+  ```shell
+  abbr (list-commands | L) [<SCOPE>] [<TYPE>]
+  ```
+
+  List as commands suitable for export, like zsh's `alias -L`. Regular abbreviations follow global abbreviations. Session abbreviations follow user abbreviations.
+
+  ```shell
+  % abbr a=apple
+  % abbr -g b=ball
+  % abbr -S c=cat
+  % abbr -S -g d=dog
+  % abbr list-abbreviations
+  abbr a="apple"
+  abbr -g b="ball"
+  abbr -S c="cat"
+  abbr -S -g d="dog"
+  % source ~/.zshrc
+  % abbr list-abbreviations
+  abbr a="apple"
+  abbr -g b="ball"
+  ```
+
+- **`rename`**
+
+  ```shell
+  abbr (rename | R) [<SCOPE>] [<TYPE>] [--dry-run] [--quiet] OLD NEW
+  ```
+
+  Rename an abbreviation.
+
+  Use the **--session** or **-S** scope flag to rename a session abbreviation. Otherwise, or if the **--user** or **-U** scope flag is used, a cross-session abbreviation will be renamed.
+
+  Use the **--global** flag to rename a global abbreviation. Otherwise a command abbreviation will be renamed.
+
+  Rename is scope- and type-specific. If you get a "no matching abbreviation" error, make sure you added the right flags (list abbreviations if you are not sure).
+
+  ```shell
+  % abbr add gcm git checkout main
+  % gcm[Space] # expands to git checkout main
+  % gm[Space] # no expansion
+  % abbr rename gcm[Ctrl-Space] gm
+  % gcm[Space] # no expansion
+  % gm[Space] # expands to git checkout main
+  ```
+
+  Use `--dry-run` to see what would result, without making any actual changes.
+
+  Abbreviations can also be manually renamed in the `ABBR_USER_ABBREVIATIONS_FILE`. See **Storage** below.
 
 ## Advanced
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ zsh-abbr has commands to add, rename, and erase abbreviations; to add abbreviati
 - **`export-aliases`**
 
   ```shell
-  abbr export-aliases [<SCOPE>] [<TYPE>] [DESTINATION]
+  abbr export-aliases [<SCOPE>] [<TYPE>]
   ```
 
   Export abbreviations as alias commands. Regular abbreviations follow global abbreviations. Session abbreviations follow user abbreviations.
@@ -232,10 +232,6 @@ zsh-abbr has commands to add, rename, and erase abbreviations; to add abbreviati
   % abbr export-aliases
   alias gcm='git checkout main'
   % abbr export-aliases --session
-  alias g='git'
-  % abbr export-aliases ~/.zshrc
-  % cat ~/.zshrc
-  # -- snip --
   alias g='git'
   ```
 

--- a/README.md
+++ b/README.md
@@ -584,23 +584,9 @@ Thanks for your interest. Contributions are welcome!
 
 > Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
-Check the [Issues](https://github.com/olets/zsh-abbr/issues) to see if your topic has been discussed before or if it is being worked on. You may also want to check the roadmap (see above). Discussing in an Issue before opening a Pull Request means future contributors only have to search in one place.
+Check the [Issues](https://github.com/olets/zsh-abbr/issues) to see if your topic has been discussed before or if it is being worked on. You may also want to check the roadmap (see above).
 
-This project loosely follows the [Angular commit message conventions](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit). This helps with searchability and with the changelog, which is generated automatically and touched up by hand only if necessary. Use the commit message format `<type>(<scope>): <subject>`, where `<type>` is **feat** for new or changed behavior, **fix** for fixes, **docs** for documentation, **style** for under the hood changes related to for example zshisms, **refactor** for other refactors, **test** for tests, or **chore** chore for general maintenance (this will be used primarily by maintainers not contributors, for example for version bumps). `<scope>` is more loosely defined.
-
-Tests are in the `tests` directory. To run them, replace `zsh-abbr` with `zsh-abbr/tests` in .zshrc. For example, zinit users will run
-
-```shell
-zinit light olets/zsh-abbr/tests
-```
-
-in place of
-
-```shell
-zinit light olets/zsh-abbr
-```
-
-Open a new session and the tests will run.
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -473,12 +473,12 @@ In addition to the following, setting `NO_COLOR` (regardless of its value) will 
 
 Variable | Type | Use | Default
 ---|---|---|---
-`ABBR_AUTOLOAD` | integer Boolean | If non-zero, automatically account for updates to the user abbrevations file (see [Storage and manual editing](#storage-and-manual-editing)) | 1
-`ABBR_DEBUG` | integer Boolean | If non-zero, print debugging messages | 0
-`ABBR_DEFAULT_BINDINGS` | integer Boolean | If non-zero, add the default bindings (see [Bindings](#bindings)) | 1
-`ABBR_DRY_RUN` | integer Boolean | If non-zero, use dry run mode without passing `--dry-run` | 0
-`ABBR_FORCE` | integer Boolean | If non-zero, use force mode without passing `--force` (see [`add`](#add)) | 0
-`ABBR_QUIET` | integer Boolean | If non-zero, use quiet mode without passing `--quiet` | 0
+`ABBR_AUTOLOAD` | integer | If non-zero, automatically account for updates to the user abbrevations file (see [Storage and manual editing](#storage-and-manual-editing)) | 1
+`ABBR_DEBUG` | integer | If non-zero, print debugging messages | 0
+`ABBR_DEFAULT_BINDINGS` | integer | If non-zero, add the default bindings (see [Bindings](#bindings)) | 1
+`ABBR_DRY_RUN` | integer | If non-zero, use dry run mode without passing `--dry-run` | 0
+`ABBR_FORCE` | integer | If non-zero, use force mode without passing `--force` (see [`add`](#add)) | 0
+`ABBR_QUIET` | integer | If non-zero, use quiet mode without passing `--quiet` | 0
 `ABBR_TMPDIR` | String | Path to the directory temporary files are stored in. _Ends in `/`_ | `${TMPDIR:-/tmp/}zsh-abbr/}`
 `ABBR_USER_ABBREVIATIONS_FILE` | String | Path to the file user abbreviation are stored in (see [Storage and manual editing](#storage-and-manual-editing)) | `$HOME/.config/zsh/abbreviations`
 
@@ -486,13 +486,13 @@ Variable | Type | Use | Default
 
 Variable | Type | Value
 ---|---|---
-`ABBR_GLOBAL_SESSION_ABBREVIATIONS` | Associative array | The global session abbreviations
-`ABBR_GLOBAL_USER_ABBREVIATIONS` | Associative array | The global user abbreviations
-`ABBR_LOADING_USER_ABBREVIATIONS` | Integer Boolean | Set to `1` when the interactive shell is refreshing its list of user abbreviations, otherwise not set
-`ABBR_REGULAR_SESSION_ABBREVIATIONS` | Associative array | The regular session abbreviations
-`ABBR_REGULAR_USER_ABBREVIATIONS` | Associative array | The regular user abbreviations
+`ABBR_GLOBAL_SESSION_ABBREVIATIONS` | associative array | The global session abbreviations
+`ABBR_GLOBAL_USER_ABBREVIATIONS` | associative array | The global user abbreviations
+`ABBR_LOADING_USER_ABBREVIATIONS` | integer | Set to `1` when the interactive shell is refreshing its list of user abbreviations, otherwise not set
+`ABBR_REGULAR_SESSION_ABBREVIATIONS` | associative array | The regular session abbreviations
+`ABBR_REGULAR_USER_ABBREVIATIONS` | associative array | The regular user abbreviations
 
-Each element in abbreviations associative arrays has the form `ABBREVIATION=EXPANSION`, and the expansion value is quoted. Scripters will probably want to remove one level of quotes, using the [Q modifier](http://zsh.sourceforge.net/Doc/Release/Expansion.html#Modifiers) (e.g. `for v in ${(Qv)ABBR_REGULAR_USER_ABBREVIATIONS}...`)
+Each element in `ABBR_GLOBAL_SESSION_ABBREVIATIONS`, `ABBR_GLOBAL_USER_ABBREVIATIONS`, `ABBR_REGULAR_SESSION_ABBREVIATIONS`, and `ABBR_REGULAR_USER_ABBREVIATIONS` has the form `ABBREVIATION=EXPANSION`.The expansion value is quoted. Scripters will probably want to remove one level of quotes, using the [Q modifier](http://zsh.sourceforge.net/Doc/Release/Expansion.html#Modifiers) (e.g. `for v in ${(Qv)ABBR_REGULAR_USER_ABBREVIATIONS}...`).
 
 ### Storage and manual editing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,17 +12,14 @@ Key:
 - [ ] Identify someone who contributors can contact if olets violates the code of conduct (note: not looking for volunteers)
 - [ ] Update code of conduct with their information
 
-## 3.x
-
-- [ ] maybe split abbr into its own file, and autoload it?
-- [ ] maybe add to Snapcraft?
-
 ## 4.0
 
-- [ ] drop the `_zsh_` and `ZSH_` prefixes from functions and vars
+- [x] drop the `_zsh_` and `ZSH_` prefixes from functions and vars
 - [ ] stop cleaning up the deprecated temp files
 
-## Chrome
+## Maybes
 
 - [ ] Completion
 - [ ] highlighting
+- [ ] maybe split abbr into its own file, and autoload it?
+- [ ] maybe add to Snapcraft?

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,6 +16,7 @@ Key:
 
 - [x] drop the `_zsh_` and `ZSH_` prefixes from functions and vars
 - [x] stop cleaning up the deprecated temp files
+- [x] drop support for deprecated subcommands
 
 ## Maybes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ Key:
 ## 4.0
 
 - [x] drop the `_zsh_` and `ZSH_` prefixes from functions and vars
-- [ ] stop cleaning up the deprecated temp files
+- [x] stop cleaning up the deprecated temp files
 
 ## Maybes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,16 +14,15 @@ Key:
 
 ## 3.x
 
-- [x] deprecate the `_zsh_` and `ZSH_` prefixes from functions and vars
-- [ ] maybe split abbr into its own file, and autoload it
-- [ ] add to Snapcraft
+- [ ] maybe split abbr into its own file, and autoload it?
+- [ ] maybe add to Snapcraft?
 
 ## 4.0
 
 - [ ] drop the `_zsh_` and `ZSH_` prefixes from functions and vars
 - [ ] stop cleaning up the deprecated temp files
 
-Chrome
+## Chrome
 
 - [ ] Completion
 - [ ] highlighting

--- a/man/abbr.txt
+++ b/man/abbr.txt
@@ -51,8 +51,8 @@ DESCRIPTION
        runs automatically before each of the above commands.
 
 
-Options
-       The following options are available:
+Commands
+       The following commands are available:
 
 
        o      add abbreviation expansion or a abbreviation expansion
@@ -133,7 +133,7 @@ Options
               Show the current version.
 
 
-       All options except for clear-session and expand can take a scope:
+       All commands except for clear-session and expand can take a scope:
 
               o      --session or -S
 

--- a/man/abbr.txt
+++ b/man/abbr.txt
@@ -14,7 +14,7 @@ SYNOPSIS
 
        abbr (expand | x) <abbreviation>
 
-       abbr (export-aliases | -o) <scope> [<destination>]
+       abbr (export-aliases | -o) <scope>
 
        abbr import-aliases [scope]
 
@@ -84,8 +84,7 @@ Commands
        o      export-aliases [<destination>]
 
               Exports a list of alias command for user abbreviations, suitable
-              for pasting or piping to whereever you keep aliases. If a  <des-
-              tination> is provided, the commands will be appended to it.
+              for pasting or piping to whereever you keep aliases.
 
 
        o      import-aliases
@@ -100,13 +99,13 @@ Commands
 
        o      import-git-aliases
 
-              Adds  two  abbreviations for each git alias: a regular abbrevia-
+              Adds two abbreviations for each git alias: a  regular  abbrevia-
               tion, and a "g"-prefixed global abbreviation.
 
 
        o      abbr list
 
-              Lists the  available  abbreviations  without  their  expansions.
+              Lists  the  available  abbreviations  without  their expansions.
               Equivalent to fish's `abbr --list`.
 
 
@@ -117,14 +116,14 @@ Commands
 
        o      list-commands or L
 
-              Lists  all  abbreviations  as  commands  suitable for export and
+              Lists all abbreviations as  commands  suitable  for  export  and
               import.
 
 
-       o      rename old_abbreviation new_abbreviation or  R  old_abbreviation
+       o      rename  old_abbreviation  new_abbreviation or R old_abbreviation
               new_abbreviation
 
-              Renames  an abbreviation, from old_abbreviation to new_abbrevia-
+              Renames an abbreviation, from old_abbreviation to  new_abbrevia-
               tion.
 
 
@@ -142,17 +141,17 @@ Commands
 
               o      --user or -U
 
-                     Abbreviations available to all current  and  future  ses-
+                     Abbreviations  available  to  all current and future ses-
                      sions.
 
 
-       All  except  for  clear-session,  expand,  import-fish, and import-git-
+       All except for  clear-session,  expand,  import-fish,  and  import-git-
        aliases can take a type:
 
 
               o      --global or -g
 
-                     Abbreviation will expand anywhere on a line, rather  than
+                     Abbreviation  will expand anywhere on a line, rather than
                      only in command (first word) position.
 
 
@@ -162,14 +161,14 @@ Commands
                      only.
 
 
-       All except for clear-session,  expand,  export-aliases,  list-abbrevia-
+       All  except  for  clear-session, expand, export-aliases, list-abbrevia-
        tions, and list-commands can be tried without making changes:
 
 
-              o      --dry-run  Show whats the result of the command would be.
+              o      --dry-run Show whats the result of the command would  be.
 
 
-       All except for clear-session,  expand,  export-aliases,  list-abbrevia-
+       All  except  for  clear-session, expand, export-aliases, list-abbrevia-
        tions, and list-commands can be run with reduced output:
 
 
@@ -180,41 +179,41 @@ Configuration
        The following variables may be set:
 
 
-       o      ABBR_AUTOLOAD  Should  `abbr  load` run before every `abbr` com-
+       o      ABBR_AUTOLOAD Should `abbr load` run before  every  `abbr`  com-
               mand? (0 or 1, default 1)
 
 
-       o      ABBR_DEFAULT_BINDINGS Use the default key  bindings?  (0  or  1,
+       o      ABBR_DEFAULT_BINDINGS  Use  the  default  key bindings? (0 or 1,
               default 1)
 
 
        o      ABBR_DEBUG Print debugging logs? (0 or 1, default 0)
 
 
-       o      ABBR_DRY_RUN  Behave  as  if  `--dry-run`  was  passed? (0 or 1,
+       o      ABBR_DRY_RUN Behave as if  `--dry-run`  was  passed?  (0  or  1,
               default 0)
 
 
-       o      ABBR_FORCE Behave as if `--force` was passed? (0 or  1,  default
+       o      ABBR_FORCE  Behave  as if `--force` was passed? (0 or 1, default
               0)
 
 
-       o      ABBR_QUIET  Behave  as if `--quiet` was passed? (0 or 1, default
+       o      ABBR_QUIET Behave as if `--quiet` was passed? (0 or  1,  default
               0)
 
 
-       o      ABBR_USER_ABBREVIATIONS_FILE File abbreviations  are  stored  in
+       o      ABBR_USER_ABBREVIATIONS_FILE  File  abbreviations  are stored in
               (default ${HOME}/.config/zsh/abbreviations)
 
 
-       o      NO_COLOR  If  `NO_COLOR`  is  set, color output is disabled. See
+       o      NO_COLOR If `NO_COLOR` is set, color  output  is  disabled.  See
               https://no-color.org/.
 
 
 EXAMPLES
        abbr gco="git checkout"
 
-              "gco" will be expanded as "git checkout" when it  is  the  first
+              "gco"  will  be  expanded as "git checkout" when it is the first
               word in the command, in all open and future sessions.
 
 
@@ -232,9 +231,9 @@ EXAMPLES
 
        abbr e -S -g gco;
 
-              Erase  the  global session abbreviation "gco". Note that because
+              Erase the global session abbreviation "gco". Note  that  because
               expansion is triggered by [SPACE] and [ENTER], the semicolon (;)
-              is  necessary  to  prevent  expansion  when  operating on global
+              is necessary to  prevent  expansion  when  operating  on  global
               abbreviations.
 
 

--- a/man/man1/abbr.1
+++ b/man/man1/abbr.1
@@ -11,7 +11,7 @@ zsh\-abbr \- manage zsh abbreviations
 
 \fBabbr\fR (\fBexpand\fR | \fBx\fR) <\fIabbreviation\fR>
 
-\fBabbr\fR (\fBexport\-aliases\fR | \fB\-o\fR) <\fIscope\fI> [<\fIdestination\fR>]
+\fBabbr\fR (\fBexport\-aliases\fR | \fB\-o\fR) <\fIscope\fI>
 
 \fBabbr import\-aliases\fR [\fIscope\fR]
 
@@ -72,7 +72,7 @@ Returns the \fIexpansion\fR of the abbreviation \fIabbreviation\fR.
 .IP \(bu
 \fBexport\-aliases\fR [<\fIdestination\fR>]
 
-Exports a list of alias command for user abbreviations, suitable for pasting or piping to whereever you keep aliases. If a <\fIdestination\fR> is provided, the commands will be appended to it.
+Exports a list of alias command for user abbreviations, suitable for pasting or piping to whereever you keep aliases.
 
 .IP \(bu
 \fBimport\-aliases\fR

--- a/man/man1/abbr.1
+++ b/man/man1/abbr.1
@@ -42,8 +42,8 @@ To prevent expansion, press [\fBCTRL\-SPACE\fR] in place of [\fBSPACE\fR].
 
 \fBabbr-load\fR triggers a reload of the user abbreviations files. This also runs automatically before each of the above commands.
 
-.SH Options
-The following options are available:
+.SH Commands
+The following commands are available:
 
 .IP \(bu
 \fBadd \fIabbreviation\fR \fIexpansion\fR or \fBa\fR \fIabbreviation\fR \fIexpansion\fR
@@ -115,7 +115,7 @@ Renames an abbreviation, from \fIold_abbreviation\fR to \fInew_abbreviation\fR.
 Show the current version.
 
 .PP
-All options except for \fBclear-session\fR and \fBexpand\fR can take a \fBscope\fR:
+All commands except for \fBclear-session\fR and \fBexpand\fR can take a \fBscope\fR:
 .RS
 .IP \(bu
 \fB\-\-session\fR

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -312,10 +312,10 @@ _abbr() {
         value=${git_alias#* }
 
         if [[ ${value[1]} == '!' ]]; then
-          verb_phrase="was not imported"
-          ((dry_run)) && verb_phrase="would not be imported"
+          verb_phrase="Did not"
+          ((dry_run)) && verb_phrase="Would not"
 
-          _abbr:util_warn "The Git alias \`$key\` $verb_phrase because its expansion is a function"
+          _abbr:util_warn "$verb_phrase import the Git alias \`$key\` because its expansion is a function"
         else
           if ! (( ABBR_LOADING_USER_ABBREVIATIONS )); then
             key=${(q)key}
@@ -510,10 +510,10 @@ _abbr() {
 
         _abbr:util_log "${success_color}$verb_phrase%f the ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\`"
       else
-        verb_phrase="was not added"
-        (( dry_run )) && verb_phrase="would not be added"
+        verb_phrase="Did not"
+        (( dry_run )) && verb_phrase="Would not"
 
-        _abbr:util_error "The ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\` $verb_phrase because it already exists"
+        _abbr:util_error "$verb_phrase add the ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\` because it already exists"
       fi
     }
 
@@ -587,10 +587,10 @@ _abbr() {
 
             _abbr:util_log "\`$abbreviation\` $verb_phrase as an abbreviation"
           else
-            verb_phrase="was not added"
-            (( dry_run )) && verb_phrase="would not be added"
+            verb_phrase="Did not"
+            (( dry_run )) && verb_phrase="Would not"
 
-            _abbr:util_warn "The abbreviation \`$abbreviation\` $verb_phrase because a command with the same name exists"
+            _abbr:util_warn "$verb_phrase add the abbreviation \`$abbreviation\` because a command with the same name exists"
             return 1
           fi
         fi

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -52,9 +52,9 @@ _abbr() {
     version="zsh-abbr version 3.3.4"
 
     if ! (( ${+NO_COLOR} )); then
-      error_color="red"
-      success_color="green"
-      warn_color="yellow"
+      error_color="$fg[red]"
+      success_color="$fg[green]"
+      warn_color="$fg[yellow]"
     fi
 
     if (( ABBR_LOADING_USER_ABBREVIATIONS )); then
@@ -173,17 +173,15 @@ _abbr() {
           fi
         fi
 
-        _abbr:util_log "${success_color:+%F{$success_color}}$verb_phrase%f ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\`"
+        _abbr:util_log "$success_color$verb_phrase$reset_color ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\`"
       else
         verb_phrase="Did not erase"
         (( dry_run )) && verb_phrase="Would not erase"
 
-        message="${error_color:+%F{$error_color}}$verb_phrase%f abbreviation \`$abbreviation\`. Please specify one of"
-        message=$'\n'
+        message="$error_color$verb_phrase$reset_color abbreviation \`$abbreviation\`. Please specify one of\\n"
 
         for abbreviations_set in ${abbreviations_sets[@]}; do
-          message+="  ${${${abbreviations_set:l}//_/ }//abbreviations/}"
-          message=$'\n'
+          message+="  ${${${abbreviations_set:l}//_/ }//abbreviations/}\\n"
         done
 
         _abbr:util_error $message
@@ -506,7 +504,7 @@ _abbr() {
         verb_phrase="Added"
         (( dry_run )) && verb_phrase="Would add"
 
-        _abbr:util_log "${success_color:+%F{$success_color}}$verb_phrase%f the ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\`"
+        _abbr:util_log "$success_color$verb_phrase$reset_color the ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\`"
       else
         verb_phrase="Did not"
         (( dry_run )) && verb_phrase="Would not"
@@ -547,7 +545,7 @@ _abbr() {
       _abbr_debugger
 
       has_error=1
-      logs+=${logs:+$'\n'}"${error_color:+%F{$error_color}}$@%f"
+      logs+="${logs:+\\n}$error_color$@$reset_color"
       should_exit=1
     }
 
@@ -663,13 +661,13 @@ _abbr() {
     _abbr:util_log() {
       _abbr_debugger
 
-      logs+=${logs:+'\n'}"$1"
+      logs+="${logs:+\\n}$1"
     }
 
     _abbr:util_print() {
       _abbr_debugger
 
-      output+=${output:+'\n'}"$1"
+      output+="${output:+\\n}$1"
     }
 
     _abbr:util_set_once() {
@@ -723,7 +721,7 @@ _abbr() {
     _abbr:util_warn() {
       _abbr_debugger
 
-      logs+=${logs:+'\n'}"${warn_color:+%F{$warn_color}}$@%f"
+      logs+="${logs:+\\n}$warn_color$@$reset_color"
     }
 
     for opt in "$@"; do
@@ -857,7 +855,7 @@ _abbr() {
 
     if ! (( quiet )); then
       if [[ -n $logs ]]; then
-        output=$logs${output:+$'\n'$output}
+        output=$logs${output:+\\n$output}
       fi
     fi
 
@@ -867,7 +865,7 @@ _abbr() {
     else
       if (( dry_run && ! ABBR_TESTING )); then
         output+=$'\n'
-        output+="${warn_color}Dry run. Changes not saved.%f"
+        output+="\\n${warn_color}Dry run. Changes not saved.$reset_color"
       fi
 
       [[ -n $output ]] && _abbr_print -P - $output >&1

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -93,8 +93,8 @@ _abbr() {
         return
       fi
 
-      REGULAR_SESSION_ABBREVIATIONS=()
-      GLOBAL_SESSION_ABBREVIATIONS=()
+      ABBR_REGULAR_SESSION_ABBREVIATIONS=()
+      ABBR_GLOBAL_SESSION_ABBREVIATIONS=()
     }
 
     _abbr:erase() {
@@ -118,16 +118,16 @@ _abbr() {
 
       if [[ $scope != 'user' ]]; then
         if [[ $type != 'regular' ]]; then
-          if (( ${+GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]} )); then
+          if (( ${+ABBR_GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]} )); then
             (( ABBR_DEBUG )) && _abbr_echo "  Found a global session abbreviation"
-            abbreviations_sets+=( GLOBAL_SESSION_ABBREVIATIONS )
+            abbreviations_sets+=( ABBR_GLOBAL_SESSION_ABBREVIATIONS )
           fi
         fi
 
         if [[ $type != 'global' ]]; then
-          if (( ${+REGULAR_SESSION_ABBREVIATIONS[$abbreviation]} )); then
+          if (( ${+ABBR_REGULAR_SESSION_ABBREVIATIONS[$abbreviation]} )); then
             (( ABBR_DEBUG )) && _abbr_echo "  Found a regular session abbreviation"
-            abbreviations_sets+=( REGULAR_SESSION_ABBREVIATIONS )
+            abbreviations_sets+=( ABBR_REGULAR_SESSION_ABBREVIATIONS )
           fi
         fi
       fi
@@ -138,9 +138,9 @@ _abbr() {
             source ${TMPDIR:-/tmp/}zsh-abbr/global-user-abbreviations
           fi
 
-          if (( ${+GLOBAL_USER_ABBREVIATIONS[$abbreviation]} )); then
+          if (( ${+ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]} )); then
             (( ABBR_DEBUG )) && _abbr_echo "  Found a global user abbreviation"
-            abbreviations_sets+=( GLOBAL_USER_ABBREVIATIONS )
+            abbreviations_sets+=( ABBR_GLOBAL_USER_ABBREVIATIONS )
           fi
         fi
 
@@ -149,9 +149,9 @@ _abbr() {
             source ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations
           fi
 
-          if (( ${+REGULAR_USER_ABBREVIATIONS[$abbreviation]} )); then
+          if (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} )); then
             (( ABBR_DEBUG )) && _abbr_echo "  Found a regular user abbreviation"
-            abbreviations_sets+=( REGULAR_USER_ABBREVIATIONS )
+            abbreviations_sets+=( ABBR_REGULAR_USER_ABBREVIATIONS )
           fi
         fi
       fi
@@ -403,15 +403,15 @@ _abbr() {
 
       if [[ $scope == 'session' ]]; then
         if [[ $type == 'global' ]]; then
-          expansion=${GLOBAL_SESSION_ABBREVIATIONS[$current_abbreviation]}
+          expansion=${ABBR_GLOBAL_SESSION_ABBREVIATIONS[$current_abbreviation]}
         else
-          expansion=${REGULAR_SESSION_ABBREVIATIONS[$current_abbreviation]}
+          expansion=${ABBR_REGULAR_SESSION_ABBREVIATIONS[$current_abbreviation]}
         fi
       else
         if [[ $type == 'global' ]]; then
-          expansion=${GLOBAL_USER_ABBREVIATIONS[$current_abbreviation]}
+          expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[$current_abbreviation]}
         else
-          expansion=${REGULAR_USER_ABBREVIATIONS[$current_abbreviation]}
+          expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[$current_abbreviation]}
         fi
       fi
 
@@ -449,20 +449,20 @@ _abbr() {
 
       if [[ $scope == 'session' ]]; then
         if [[ $type == 'global' ]]; then
-          if ! (( ${+GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]} )); then
+          if ! (( ${+ABBR_GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]} )); then
             _abbr:util_check_command $abbreviation || return
 
             if ! (( dry_run )); then
-              GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]=$expansion
+              ABBR_GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]=$expansion
             fi
 
             success=1
           fi
-        elif ! (( ${+REGULAR_SESSION_ABBREVIATIONS[$abbreviation]} )); then
+        elif ! (( ${+ABBR_REGULAR_SESSION_ABBREVIATIONS[$abbreviation]} )); then
           _abbr:util_check_command $abbreviation || return
 
           if ! (( dry_run )); then
-            REGULAR_SESSION_ABBREVIATIONS[$abbreviation]=$expansion
+            ABBR_REGULAR_SESSION_ABBREVIATIONS[$abbreviation]=$expansion
           fi
 
           success=1
@@ -473,11 +473,11 @@ _abbr() {
             source ${TMPDIR:-/tmp/}zsh-abbr/global-user-abbreviations
           fi
 
-          if ! (( ${+GLOBAL_USER_ABBREVIATIONS[$abbreviation]} )); then
+          if ! (( ${+ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]} )); then
             _abbr:util_check_command $abbreviation || return
 
             if ! (( dry_run )); then
-              GLOBAL_USER_ABBREVIATIONS[$abbreviation]=$expansion
+              ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]=$expansion
               _abbr:util_sync_user
             fi
 
@@ -488,11 +488,11 @@ _abbr() {
             source ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations
           fi
 
-          if ! (( ${+REGULAR_USER_ABBREVIATIONS[$abbreviation]} )); then
+          if ! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} )); then
             _abbr:util_check_command $abbreviation || return
 
             if ! (( dry_run )); then
-              REGULAR_USER_ABBREVIATIONS[$abbreviation]=$expansion
+              ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]=$expansion
               _abbr:util_sync_user
             fi
 
@@ -609,15 +609,15 @@ _abbr() {
 
       if [[ $scope != 'session' ]]; then
         if [[ $type != 'regular' ]]; then
-          for abbreviation in ${(iko)GLOBAL_USER_ABBREVIATIONS}; do
-            expansion=${include_expansion:+${GLOBAL_USER_ABBREVIATIONS[$abbreviation]}}
+          for abbreviation in ${(iko)ABBR_GLOBAL_USER_ABBREVIATIONS}; do
+            expansion=${include_expansion:+${ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]}}
             _abbr:util_list_item $abbreviation $expansion ${user_prefix:+$user_prefix -g}
           done
         fi
 
         if [[ $type != 'global' ]]; then
-          for abbreviation in ${(iko)REGULAR_USER_ABBREVIATIONS}; do
-            expansion=${include_expansion:+${REGULAR_USER_ABBREVIATIONS[$abbreviation]}}
+          for abbreviation in ${(iko)ABBR_REGULAR_USER_ABBREVIATIONS}; do
+            expansion=${include_expansion:+${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]}}
             _abbr:util_list_item $abbreviation $expansion $user_prefix
           done
         fi
@@ -625,15 +625,15 @@ _abbr() {
 
       if [[ $scope != 'user' ]]; then
         if [[ $type != 'regular' ]]; then
-          for abbreviation in ${(iko)GLOBAL_SESSION_ABBREVIATIONS}; do
-            expansion=${include_expansion:+${GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]}}
+          for abbreviation in ${(iko)ABBR_GLOBAL_SESSION_ABBREVIATIONS}; do
+            expansion=${include_expansion:+${ABBR_GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]}}
             _abbr:util_list_item $abbreviation $expansion ${session_prefix:+$session_prefix -g}
           done
         fi
 
         if [[ $type != 'global' ]]; then
-          for abbreviation in ${(iko)REGULAR_SESSION_ABBREVIATIONS}; do
-            expansion=${include_expansion:+${REGULAR_SESSION_ABBREVIATIONS[$abbreviation]}}
+          for abbreviation in ${(iko)ABBR_REGULAR_SESSION_ABBREVIATIONS}; do
+            expansion=${include_expansion:+${ABBR_REGULAR_SESSION_ABBREVIATIONS[$abbreviation]}}
             _abbr:util_list_item $abbreviation $expansion $session_prefix
           done
         fi
@@ -703,15 +703,15 @@ _abbr() {
 
       user_updated=$(mktemp ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations_updated.XXXXXX)
 
-      typeset -p GLOBAL_USER_ABBREVIATIONS > ${TMPDIR:-/tmp/}zsh-abbr/global-user-abbreviations
-      for abbreviation in ${(iko)GLOBAL_USER_ABBREVIATIONS}; do
-        expansion=${GLOBAL_USER_ABBREVIATIONS[$abbreviation]}
+      typeset -p ABBR_GLOBAL_USER_ABBREVIATIONS > ${TMPDIR:-/tmp/}zsh-abbr/global-user-abbreviations
+      for abbreviation in ${(iko)ABBR_GLOBAL_USER_ABBREVIATIONS}; do
+        expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]}
         _abbr_echo "abbr -g ${abbreviation}=${(qqq)${(Q)expansion}}" >> "$user_updated"
       done
 
-      typeset -p REGULAR_USER_ABBREVIATIONS > ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations
-      for abbreviation in ${(iko)REGULAR_USER_ABBREVIATIONS}; do
-        expansion=${REGULAR_USER_ABBREVIATIONS[$abbreviation]}
+      typeset -p ABBR_REGULAR_USER_ABBREVIATIONS > ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations
+      for abbreviation in ${(iko)ABBR_REGULAR_USER_ABBREVIATIONS}; do
+        expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]}
         _abbr_echo "abbr ${abbreviation}=${(qqq)${(Q)expansion}}" >> $user_updated
       done
 
@@ -914,11 +914,11 @@ _abbr_cmd_expansion() {
   local expansion
 
   abbreviation=$1
-  expansion=${REGULAR_SESSION_ABBREVIATIONS[$abbreviation]}
+  expansion=${ABBR_REGULAR_SESSION_ABBREVIATIONS[$abbreviation]}
 
   if [[ ! $expansion ]]; then
     source ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations
-    expansion=${REGULAR_USER_ABBREVIATIONS[$abbreviation]}
+    expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]}
   fi
 
   _abbr_echo - $expansion
@@ -957,11 +957,11 @@ _abbr_global_expansion() {
   local expansion
 
   abbreviation=$1
-  expansion=${GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]}
+  expansion=${ABBR_GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]}
 
   if [[ ! $expansion ]]; then
     source ${TMPDIR:-/tmp/}zsh-abbr/global-user-abbreviations
-    expansion=${GLOBAL_USER_ABBREVIATIONS[$abbreviation]}
+    expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]}
   fi
 
   _abbr_echo - $expansion
@@ -972,14 +972,14 @@ _abbr_init() {
 
   local job
 
-  typeset -gA REGULAR_USER_ABBREVIATIONS
-  typeset -gA GLOBAL_USER_ABBREVIATIONS
-  typeset -gA REGULAR_SESSION_ABBREVIATIONS
-  typeset -gA GLOBAL_SESSION_ABBREVIATIONS
+  typeset -gA ABBR_REGULAR_USER_ABBREVIATIONS
+  typeset -gA ABBR_GLOBAL_USER_ABBREVIATIONS
+  typeset -gA ABBR_REGULAR_SESSION_ABBREVIATIONS
+  typeset -gA ABBR_GLOBAL_SESSION_ABBREVIATIONS
 
   job=$(_abbr_job_name)
-  REGULAR_SESSION_ABBREVIATIONS=()
-  GLOBAL_SESSION_ABBREVIATIONS=()
+  ABBR_REGULAR_SESSION_ABBREVIATIONS=()
+  ABBR_GLOBAL_SESSION_ABBREVIATIONS=()
 
   _abbr_job_push $job initialization
   (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
@@ -1090,8 +1090,8 @@ _abbr_load_user_abbreviations() {
     function _abbr_load_user_abbreviations:setup() {
       (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
-      REGULAR_USER_ABBREVIATIONS=()
-      GLOBAL_USER_ABBREVIATIONS=()
+      ABBR_REGULAR_USER_ABBREVIATIONS=()
+      ABBR_GLOBAL_USER_ABBREVIATIONS=()
 
       if ! [[ -d ${TMPDIR:-/tmp/}zsh-abbr ]]; then
         mkdir -p ${TMPDIR:-/tmp/}zsh-abbr
@@ -1148,8 +1148,8 @@ _abbr_load_user_abbreviations() {
         touch $ABBR_USER_ABBREVIATIONS_FILE
       fi
 
-      typeset -p REGULAR_USER_ABBREVIATIONS > ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations
-      typeset -p GLOBAL_USER_ABBREVIATIONS > ${TMPDIR:-/tmp/}zsh-abbr/global-user-abbreviations
+      typeset -p ABBR_REGULAR_USER_ABBREVIATIONS > ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations
+      typeset -p ABBR_GLOBAL_USER_ABBREVIATIONS > ${TMPDIR:-/tmp/}zsh-abbr/global-user-abbreviations
     }
 
     ABBR_LOADING_USER_ABBREVIATIONS=1

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -58,7 +58,7 @@ _abbr() {
     fi
 
     _abbr:add() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       local abbreviation
       local expansion
@@ -85,7 +85,7 @@ _abbr() {
     }
 
     _abbr:clear_session() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       if [[ $# > 0 ]]; then
         _abbr:util_error "abbr clear-session: Unexpected argument"
@@ -97,7 +97,7 @@ _abbr() {
     }
 
     _abbr:erase() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       local abbreviation
       local abbreviations_sets
@@ -185,7 +185,7 @@ _abbr() {
     }
 
     _abbr:expand() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       local abbreviation
       local expansion
@@ -206,7 +206,7 @@ _abbr() {
     }
 
     _abbr:export_aliases() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       local type_saved
       local output_path
@@ -227,7 +227,7 @@ _abbr() {
     }
 
     _abbr:import_aliases() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       local alias_to_import
       local abbreviation
@@ -263,7 +263,7 @@ _abbr() {
     }
 
     _abbr:import_fish() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       local abbreviation
       local abbreviations
@@ -288,7 +288,7 @@ _abbr() {
     }
 
     _abbr:import_git_aliases() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       local git_alias
       local git_aliases
@@ -326,7 +326,7 @@ _abbr() {
     }
 
     _abbr:list() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       if [[ $# > 0 ]]; then
         _abbr:util_error "abbr list: Unexpected argument"
@@ -337,7 +337,7 @@ _abbr() {
     }
 
     _abbr:list_commands() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       local include_expansion
       local session_prefix
@@ -356,7 +356,7 @@ _abbr() {
     }
 
     _abbr:list_abbreviations() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       local include_expansion
 
@@ -371,7 +371,7 @@ _abbr() {
     }
 
     _abbr:print_version() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       if [[ $# > 0 ]]; then
         _abbr:util_error "abbr version: Unexpected argument"
@@ -382,7 +382,7 @@ _abbr() {
     }
 
     _abbr:rename() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       local err
       local expansion
@@ -421,7 +421,7 @@ _abbr() {
     }
 
     _abbr:util_add() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       local abbreviation
       local cmd
@@ -512,7 +512,7 @@ _abbr() {
     }
 
     _abbr:util_alias() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       local abbreviation
       local abbreviations_set
@@ -539,13 +539,13 @@ _abbr() {
     }
 
     _abbr:util_bad_options() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       _abbr:util_error "abbr: Illegal combination of options"
     }
 
     _abbr:util_deprecated() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       local message
       local new
@@ -564,7 +564,7 @@ _abbr() {
     }
 
     _abbr:util_error() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       has_error=1
       logs+="${logs:+\\n}$error_color$@$reset_color"
@@ -582,7 +582,7 @@ _abbr() {
     }
 
     _abbr:util_check_command() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       local abbreviation
 
@@ -611,7 +611,7 @@ _abbr() {
     }
 
     _abbr:util_list() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       local abbreviation
       local expansion
@@ -657,7 +657,7 @@ _abbr() {
     }
 
     _abbr:util_list_item() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       local abbreviation
       local expansion
@@ -681,19 +681,19 @@ _abbr() {
     }
 
     _abbr:util_log() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       logs+="${logs:+\\n}$1"
     }
 
     _abbr:util_print() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       output+="${output:+\\n}$1"
     }
 
     _abbr:util_set_once() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       local option value
 
@@ -709,7 +709,7 @@ _abbr() {
     }
 
     _abbr:util_sync_user() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       (( ABBR_LOADING_USER_ABBREVIATIONS )) && return
 
@@ -735,13 +735,13 @@ _abbr() {
     }
 
     _abbr:util_usage() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       _abbr_man abbr 2>/dev/null || _abbr_cat ${ABBR_SOURCE_PATH}/man/abbr.txt | _abbr_less -F
     }
 
     _abbr:util_warn() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       logs+="${logs:+\\n}$warn_color$@$reset_color"
     }
@@ -889,10 +889,10 @@ _abbr() {
     fi
 
     if [[ -n $has_error ]]; then
-      [[ -n $output ]] && _abbr_echo - $output >&2
+      [[ -n $output ]] && _abbr_print - $output >&2
       return 1
     else
-      [[ -n $output ]] && _abbr_echo - $output >&1
+      [[ -n $output ]] && _abbr_print - $output >&1
       return 0
     fi
   }
@@ -901,7 +901,7 @@ _abbr() {
 _abbr_bind_widgets() {
   emulate -LR zsh
 
-  (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+  (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
   # spacebar expands abbreviations
   zle -N _abbr_expand_and_space
@@ -947,7 +947,7 @@ _abbr_deprecated() {
   if ! (( ${+NO_COLOR} )); then
     message="$fg[yellow]$message$reset_color"
   fi
-  echo $message
+  _abbr_print $message
 }
 
 _abbr_expand_and_accept() {
@@ -1008,7 +1008,7 @@ _abbr_init() {
   GLOBAL_SESSION_ABBREVIATIONS=()
 
   _abbr_job_push $job initialization
-  (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+  (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
   _abbr_load_user_abbreviations
   _abbr_job_pop $job
 }
@@ -1017,7 +1017,7 @@ _abbr_job_push() {
   emulate -LR zsh
 
   {
-    (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+    (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
     local next_job
     local next_job_age
@@ -1035,7 +1035,7 @@ _abbr_job_push() {
     timeout_age=30 # seconds
 
     function _abbr_job_push:add_job() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       if ! [[ -d $job_dir ]]; then
         mkdir -p $job_dir
@@ -1051,15 +1051,15 @@ _abbr_job_push() {
     }
 
     function _abbr_job_push:handle_timeout() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       next_job_path=$job_dir/$next_job
 
-      _abbr_echo "abbr: A job added at $(strftime '%T %b %d %Y' ${next_job%.*}) has timed out."
-      _abbr_echo "The job was related to $(cat $next_job_path)."
-      _abbr_echo "This could be the result of manually terminating an abbr activity, for example during session startup."
-      _abbr_echo "If you believe it reflects a abbr bug, please report it at https://github.com/olets/zsh-abbr/issues/new"
-      _abbr_echo
+      _abbr_print "abbr: A job added at $(strftime '%T %b %d %Y' ${next_job%.*}) has timed out."
+      _abbr_print "The job was related to $(cat $next_job_path)."
+      _abbr_print "This could be the result of manually terminating an abbr activity, for example during session startup."
+      _abbr_print "If you believe it reflects a abbr bug, please report it at https://github.com/olets/zsh-abbr/issues/new"
+      _abbr_print
 
       rm $next_job_path &>/dev/null
     }
@@ -1090,7 +1090,7 @@ _abbr_job_push() {
 _abbr_job_pop() {
   emulate -LR zsh
 
-  (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+  (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
   local job
 
@@ -1111,10 +1111,10 @@ _abbr_load_user_abbreviations() {
   emulate -LR zsh
 
   {
-    (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+    (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
     function _abbr_load_user_abbreviations:setup() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       REGULAR_USER_ABBREVIATIONS=()
       GLOBAL_USER_ABBREVIATIONS=()
@@ -1133,7 +1133,7 @@ _abbr_load_user_abbreviations() {
     }
 
     function _abbr_load_user_abbreviations:load() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       local abbreviation
       local arguments
@@ -1220,6 +1220,10 @@ _abbr_wrap_external_commands() {
   _abbr_man() {
     \command \man $@
   }
+
+  _abbr_print() {
+    \builtin \print $@
+  }
 }
 
 # WIDGETS
@@ -1261,7 +1265,7 @@ zle -N _abbr_expand_widget
 abbr() {
   emulate -LR zsh
 
-  (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+  (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
   _abbr $*
 }
 

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -48,9 +48,9 @@ _abbr() {
     version="zsh-abbr version 3.3.4"
 
     if ! (( ${+NO_COLOR} )); then
-      error_color="$fg[red]"
-      success_color="$fg[green]"
-      warn_color="$fg[yellow]"
+      error_color="red"
+      success_color="green"
+      warn_color="yellow"
     fi
 
     if (( ABBR_LOADING_USER_ABBREVIATIONS )); then
@@ -169,15 +169,17 @@ _abbr() {
           fi
         fi
 
-        _abbr:util_log "$success_color$verb_phrase$reset_color ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\`"
+        _abbr:util_log "${success_color:+%F{$success_color}}$verb_phrase%f ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\`"
       else
         verb_phrase="Did not erase"
         (( dry_run )) && verb_phrase="Would not erase"
 
-        message="$error_color$verb_phrase$reset_color abbreviation \`$abbreviation\`. Please specify one of\\n"
+        message="${error_color:+%F{$error_color}}$verb_phrase%f abbreviation \`$abbreviation\`. Please specify one of"
+        message=$'\n'
 
         for abbreviations_set in ${abbreviations_sets[@]}; do
-          message+="  ${${${abbreviations_set:l}//_/ }//abbreviations/}\\n"
+          message+="  ${${${abbreviations_set:l}//_/ }//abbreviations/}"
+          message=$'\n'
         done
 
         _abbr:util_error $message
@@ -502,7 +504,7 @@ _abbr() {
         verb_phrase="Added"
         (( dry_run )) && verb_phrase="Would add"
 
-        _abbr:util_log "$success_color$verb_phrase$reset_color the ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\`"
+        _abbr:util_log "${success_color:+%F{$success_color}}$verb_phrase%f the ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\`"
       else
         verb_phrase="was not added"
         (( dry_run )) && verb_phrase="would not be added"
@@ -567,7 +569,7 @@ _abbr() {
       (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       has_error=1
-      logs+="${logs:+\\n}$error_color$@$reset_color"
+      logs+=${logs:+$'\n'}"${error_color:+%F{$error_color}}$@%f"
       should_exit=1
     }
 
@@ -683,13 +685,13 @@ _abbr() {
     _abbr:util_log() {
       (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
-      logs+="${logs:+\\n}$1"
+      logs+=${logs:+'\n'}"$1"
     }
 
     _abbr:util_print() {
       (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
-      output+="${output:+\\n}$1"
+      output+=${output:+'\n'}"$1"
     }
 
     _abbr:util_set_once() {
@@ -743,7 +745,7 @@ _abbr() {
     _abbr:util_warn() {
       (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
-      logs+="${logs:+\\n}$warn_color$@$reset_color"
+      logs+=${logs:+'\n'}"${warn_color:+%F{$warn_color}}$@%f"
     }
 
     for opt in "$@"; do
@@ -880,19 +882,20 @@ _abbr() {
 
     if ! (( quiet )); then
       if [[ -n $logs ]]; then
-        output=$logs${output:+\\n$output}
+        output=$logs${output:+$'\n'$output}
       fi
 
       if (( dry_run )); then
-        logs+="\\n${warn_color}Dry run. Changes not saved.$reset_color"
+        logs+=$'\n'
+        logs+="${warn_color:+%F{$warn_color}}Dry run. Changes not saved.%f"
       fi
     fi
 
     if [[ -n $has_error ]]; then
-      [[ -n $output ]] && _abbr_print - $output >&2
+      [[ -n $output ]] && _abbr_print -P - $output >&2
       return 1
     else
-      [[ -n $output ]] && _abbr_print - $output >&1
+      [[ -n $output ]] && _abbr_print -P - $output >&1
       return 0
     fi
   }
@@ -945,7 +948,7 @@ _abbr_deprecated() {
 
   message="$1 is deprecated. Please use $2 instead."
   if ! (( ${+NO_COLOR} )); then
-    message="$fg[yellow]$message$reset_color"
+    message="%F{yellow}$message%f"
   fi
   _abbr_print $message
 }

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -1198,35 +1198,35 @@ _abbr_wrap_external_commands() {
   emulate -LR zsh
 
   _abbr_alias() {
-    \builtin \alias $@
+    'builtin' 'alias' $@
   }
 
   _abbr_cat() {
-    \command \cat $@
+    'command' 'cat' $@
   }
 
   _abbr_command() {
-    \builtin \command $@
+    'builtin' 'command' $@
   }
 
   _abbr_echo() {
-    \builtin \echo $@
+    'builtin' 'echo' $@
   }
 
   _abbr_less() {
-    \command \less $@
+    'command' 'less' $@
   }
 
   _abbr_ls() {
-    \command \ls $@
+    'command' 'ls' $@
   }
 
   _abbr_man() {
-    \command \man $@
+    'command' 'man' $@
   }
 
   _abbr_print() {
-    \builtin \print $@
+    'builtin' 'print' $@
   }
 }
 

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -59,7 +59,7 @@ _abbr() {
     fi
 
     _abbr:add() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       local abbreviation
       local expansion
@@ -86,7 +86,7 @@ _abbr() {
     }
 
     _abbr:clear_session() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       if [[ $# > 0 ]]; then
         _abbr:util_error "abbr clear-session: Unexpected argument"
@@ -98,7 +98,7 @@ _abbr() {
     }
 
     _abbr:erase() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       local abbreviation
       local abbreviations_sets
@@ -188,7 +188,7 @@ _abbr() {
     }
 
     _abbr:expand() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       local abbreviation
       local expansion
@@ -209,7 +209,7 @@ _abbr() {
     }
 
     _abbr:export_aliases() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       local type_saved
       local output_path
@@ -230,7 +230,7 @@ _abbr() {
     }
 
     _abbr:import_aliases() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       local alias_to_import
       local abbreviation
@@ -266,7 +266,7 @@ _abbr() {
     }
 
     _abbr:import_fish() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       local abbreviation
       local abbreviations
@@ -291,7 +291,7 @@ _abbr() {
     }
 
     _abbr:import_git_aliases() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       local git_alias
       local git_aliases
@@ -329,7 +329,7 @@ _abbr() {
     }
 
     _abbr:list() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       if [[ $# > 0 ]]; then
         _abbr:util_error "abbr list: Unexpected argument"
@@ -340,7 +340,7 @@ _abbr() {
     }
 
     _abbr:list_commands() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       local include_expansion
       local session_prefix
@@ -359,7 +359,7 @@ _abbr() {
     }
 
     _abbr:list_abbreviations() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       local include_expansion
 
@@ -374,7 +374,7 @@ _abbr() {
     }
 
     _abbr:print_version() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       if [[ $# > 0 ]]; then
         _abbr:util_error "abbr version: Unexpected argument"
@@ -385,7 +385,7 @@ _abbr() {
     }
 
     _abbr:rename() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       local err
       local expansion
@@ -424,7 +424,7 @@ _abbr() {
     }
 
     _abbr:util_add() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       local abbreviation
       local cmd
@@ -515,7 +515,7 @@ _abbr() {
     }
 
     _abbr:util_alias() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       local abbreviation
       local abbreviations_set
@@ -542,13 +542,13 @@ _abbr() {
     }
 
     _abbr:util_bad_options() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       _abbr:util_error "abbr: Illegal combination of options"
     }
 
     _abbr:util_error() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       has_error=1
       logs+=${logs:+$'\n'}"${error_color}$@%f"
@@ -566,7 +566,7 @@ _abbr() {
     }
 
     _abbr:util_check_command() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       local abbreviation
 
@@ -595,7 +595,7 @@ _abbr() {
     }
 
     _abbr:util_list() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       local abbreviation
       local expansion
@@ -641,7 +641,7 @@ _abbr() {
     }
 
     _abbr:util_list_item() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       local abbreviation
       local expansion
@@ -665,19 +665,19 @@ _abbr() {
     }
 
     _abbr:util_log() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       logs+=${logs:+'\n'}"$1"
     }
 
     _abbr:util_print() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       output+=${output:+'\n'}"$1"
     }
 
     _abbr:util_set_once() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       local option value
 
@@ -693,7 +693,7 @@ _abbr() {
     }
 
     _abbr:util_sync_user() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       (( ABBR_LOADING_USER_ABBREVIATIONS )) && return
 
@@ -719,13 +719,13 @@ _abbr() {
     }
 
     _abbr:util_usage() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       _abbr_man abbr 2>/dev/null || _abbr_cat ${ABBR_SOURCE_PATH}/man/abbr.txt | _abbr_less -F
     }
 
     _abbr:util_warn() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       logs+=${logs:+'\n'}"${warn_color}$@%f"
     }
@@ -886,7 +886,7 @@ _abbr() {
 _abbr_bind_widgets() {
   emulate -LR zsh
 
-  (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+  _abbr_debugger
 
   # spacebar expands abbreviations
   zle -N _abbr_expand_and_space
@@ -922,6 +922,12 @@ _abbr_cmd_expansion() {
   fi
 
   _abbr_echo - $expansion
+}
+
+_abbr_debugger() {
+  emulate -LR zsh
+
+  (( ABBR_DEBUG )) && _abbr_print $funcstack[2]
 }
 
 _abbr_expand_and_accept() {
@@ -982,7 +988,7 @@ _abbr_init() {
   ABBR_GLOBAL_SESSION_ABBREVIATIONS=()
 
   _abbr_job_push $job initialization
-  (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+  _abbr_debugger
   _abbr_load_user_abbreviations
   _abbr_job_pop $job
 }
@@ -991,7 +997,7 @@ _abbr_job_push() {
   emulate -LR zsh
 
   {
-    (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+    _abbr_debugger
 
     local next_job
     local next_job_age
@@ -1009,7 +1015,7 @@ _abbr_job_push() {
     timeout_age=30 # seconds
 
     function _abbr_job_push:add_job() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       if ! [[ -d $job_dir ]]; then
         mkdir -p $job_dir
@@ -1025,7 +1031,7 @@ _abbr_job_push() {
     }
 
     function _abbr_job_push:handle_timeout() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       next_job_path=$job_dir/$next_job
 
@@ -1064,7 +1070,7 @@ _abbr_job_push() {
 _abbr_job_pop() {
   emulate -LR zsh
 
-  (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+  _abbr_debugger
 
   local job
 
@@ -1085,10 +1091,10 @@ _abbr_load_user_abbreviations() {
   emulate -LR zsh
 
   {
-    (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+    _abbr_debugger
 
     function _abbr_load_user_abbreviations:setup() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       ABBR_REGULAR_USER_ABBREVIATIONS=()
       ABBR_GLOBAL_USER_ABBREVIATIONS=()
@@ -1107,7 +1113,7 @@ _abbr_load_user_abbreviations() {
     }
 
     function _abbr_load_user_abbreviations:load() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+      _abbr_debugger
 
       local abbreviation
       local arguments
@@ -1238,7 +1244,7 @@ zle -N _abbr_expand_widget
 abbr() {
   emulate -LR zsh
 
-  (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
+  _abbr_debugger
   _abbr $*
 }
 

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -755,17 +755,11 @@ _abbr() {
 
       case $opt in
         "add"|\
-        "a"|\
-        "--add"|\
-        "-a")
-          [[ $opt[1] == '-' ]] && _abbr:util_deprecated $opt ${opt##*-}
+        "a")
           _abbr:util_set_once action add
           ;;
         "clear-session"|\
-        "c"|\
-        "--clear-session"|\
-        "-c")
-          [[ $opt[1] == '-' ]] && _abbr:util_deprecated $opt ${opt##*-}
+        "c")
           _abbr:util_set_once action clear_session
           ;;
         "--dry-run")
@@ -773,22 +767,14 @@ _abbr() {
           ((number_opts++))
           ;;
         "erase"|\
-        "e"|\
-        "--erase"|\
-        "-e")
-          [[ $opt[1] == '-' ]] && _abbr:util_deprecated $opt ${opt##*-}
+        "e")
           _abbr:util_set_once action erase
           ;;
         "expand"|\
-        "x"|\
-        "--expand"|\
-        "-x")
-          [[ $opt[1] == '-' ]] && _abbr:util_deprecated $opt ${opt##*-}
+        "x")
           _abbr:util_set_once action expand
           ;;
-        "export-aliases"|\
-        "--export-aliases")
-          [[ $opt[1] == '-' ]] && _abbr:util_deprecated $opt ${opt##*-}
+        "export-aliases")
           _abbr:util_set_once action export_aliases
           ;;
         "--force"|\
@@ -801,47 +787,33 @@ _abbr() {
           _abbr:util_set_once type global
           ;;
         "help"|\
-        "--help"|\
-        "-h")
+        "--help")
           _abbr:util_usage
           should_exit=1
           ;;
-        "import-aliases"|\
-        "--import-aliases")
-          [[ $opt[1] == '-' ]] && _abbr:util_deprecated $opt ${opt##*-}
+        "import-aliases")
           _abbr:util_set_once action import_aliases
           importing=1
           ;;
-        "import-fish"|\
-        "--import-fish")
-          [[ $opt[1] == '-' ]] && _abbr:util_deprecated $opt ${opt##*-}
+        "import-fish")
           _abbr:util_set_once action import_fish
           importing=1
           ;;
-        "import-git-aliases"|\
-        "--import-git-aliases")
-          [[ $opt[1] == '-' ]] && _abbr:util_deprecated $opt ${opt##*-}
+        "import-git-aliases")
           _abbr:util_set_once action import_git_aliases
           importing=1
           ;;
-        "list"|\
-        "--list")
-          [[ $opt[1] == '-' ]] && _abbr:util_deprecated $opt ${opt##*-}
+        "list")
           _abbr:util_set_once action list
           ;;
         "list-abbreviations"|\
-        "l"|\
-        "--list-abbreviations"|\
-        "-l")
-          [[ $opt[1] == '-' ]] && _abbr:util_deprecated $opt ${opt##*-}
+        "l")
           _abbr:util_set_once action list_abbreviations
           ;;
         "list-commands"|\
         "L"|\
-        "--list-commands"|\
         "-L")
-          # -L option will continue to be supported to match the builtin alias's `-L`
-          [[ $opt[1] == '--' ]] && _abbr:util_deprecated $opt ${opt##*-}
+          # -L option is to match the builtin alias's `-L`
           _abbr:util_set_once action list_commands
           ;;
         "load")
@@ -858,20 +830,12 @@ _abbr() {
           _abbr:util_set_once type regular
           ;;
         "rename"|\
-        "R"|\
-        "--rename"|\
-        "-R")
-          [[ $opt[1] == '-' ]] && _abbr:util_deprecated $opt ${opt##*-}
+        "R")
           _abbr:util_set_once action rename
           ;;
         "--session"|\
         "-S")
           _abbr:util_set_once scope session
-          ;;
-        "--show"|\
-        "-s")
-          _abbr:util_deprecated $opt "--list-commands or -L"
-          _abbr:util_set_once action list_commands
           ;;
         "--user"|\
         "-U")

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -27,6 +27,9 @@ typeset -gi ABBR_FORCE=${ABBR_FORCE:-0}
 # Behave as if `--quiet` was passed? (default false)
 typeset -gi ABBR_QUIET=${ABBR_QUIET:-0}
 
+# Temp files are stored in
+typeset -g ABBR_TMPDIR=${ABBR_TMPDIR:-${TMPDIR:-/tmp/}zsh-abbr/}
+
 # File abbreviations are stored in
 typeset -g ABBR_USER_ABBREVIATIONS_FILE=${ABBR_USER_ABBREVIATIONS_FILE:-$HOME/.config/zsh/abbreviations}
 
@@ -135,7 +138,7 @@ _abbr() {
       if [[ $scope != 'session' ]]; then
         if [[ $type != 'regular' ]]; then
           if ! (( ABBR_LOADING_USER_ABBREVIATIONS )); then
-            source ${TMPDIR:-/tmp/}zsh-abbr/global-user-abbreviations
+            source ${ABBR_TMPDIR}global-user-abbreviations
           fi
 
           if (( ${+ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]} )); then
@@ -146,7 +149,7 @@ _abbr() {
 
         if [[ $type != 'global' ]]; then
           if ! (( ABBR_LOADING_USER_ABBREVIATIONS )); then
-            source ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations
+            source ${ABBR_TMPDIR}regular-user-abbreviations
           fi
 
           if (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} )); then
@@ -470,7 +473,7 @@ _abbr() {
       else
         if [[ $type == 'global' ]]; then
           if ! (( ABBR_LOADING_USER_ABBREVIATIONS )); then
-            source ${TMPDIR:-/tmp/}zsh-abbr/global-user-abbreviations
+            source ${ABBR_TMPDIR}global-user-abbreviations
           fi
 
           if ! (( ${+ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]} )); then
@@ -485,7 +488,7 @@ _abbr() {
           fi
         else
           if ! (( ABBR_LOADING_USER_ABBREVIATIONS )); then
-            source ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations
+            source ${ABBR_TMPDIR}regular-user-abbreviations
           fi
 
           if ! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} )); then
@@ -701,15 +704,15 @@ _abbr() {
       local expansion
       local user_updated
 
-      user_updated=$(mktemp ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations_updated.XXXXXX)
+      user_updated=$(mktemp ${ABBR_TMPDIR}regular-user-abbreviations_updated.XXXXXX)
 
-      typeset -p ABBR_GLOBAL_USER_ABBREVIATIONS > ${TMPDIR:-/tmp/}zsh-abbr/global-user-abbreviations
+      typeset -p ABBR_GLOBAL_USER_ABBREVIATIONS > ${ABBR_TMPDIR}global-user-abbreviations
       for abbreviation in ${(iko)ABBR_GLOBAL_USER_ABBREVIATIONS}; do
         expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]}
         _abbr_echo "abbr -g ${abbreviation}=${(qqq)${(Q)expansion}}" >> "$user_updated"
       done
 
-      typeset -p ABBR_REGULAR_USER_ABBREVIATIONS > ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations
+      typeset -p ABBR_REGULAR_USER_ABBREVIATIONS > ${ABBR_TMPDIR}regular-user-abbreviations
       for abbreviation in ${(iko)ABBR_REGULAR_USER_ABBREVIATIONS}; do
         expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]}
         _abbr_echo "abbr ${abbreviation}=${(qqq)${(Q)expansion}}" >> $user_updated
@@ -914,7 +917,7 @@ _abbr_cmd_expansion() {
   expansion=${ABBR_REGULAR_SESSION_ABBREVIATIONS[$abbreviation]}
 
   if [[ ! $expansion ]]; then
-    source ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations
+    source ${ABBR_TMPDIR}regular-user-abbreviations
     expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]}
   fi
 
@@ -966,7 +969,7 @@ _abbr_global_expansion() {
   expansion=${ABBR_GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]}
 
   if [[ ! $expansion ]]; then
-    source ${TMPDIR:-/tmp/}zsh-abbr/global-user-abbreviations
+    source ${ABBR_TMPDIR}global-user-abbreviations
     expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]}
   fi
 
@@ -1010,7 +1013,7 @@ _abbr_job_push() {
 
     job_id=${(q)1}
     job_description=$2
-    job_dir=${TMPDIR:-/tmp/}zsh-abbr/jobs
+    job_dir=${ABBR_TMPDIR}jobs
     job_path=$job_dir/$job_id
     timeout_age=30 # seconds
 
@@ -1076,7 +1079,7 @@ _abbr_job_pop() {
 
   job=${(q)1}
 
-  rm ${TMPDIR:-/tmp/}zsh-abbr/jobs/$job &>/dev/null
+  rm ${ABBR_TMPDIR}jobs/$job &>/dev/null
 }
 
 _abbr_job_name() {
@@ -1103,12 +1106,12 @@ _abbr_load_user_abbreviations() {
         mkdir -p ${TMPDIR:-/tmp/}zsh-abbr
       fi
 
-      if ! [[ -f ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations ]]; then
-        touch ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations
+      if ! [[ -f ${ABBR_TMPDIR}regular-user-abbreviations ]]; then
+        touch ${ABBR_TMPDIR}regular-user-abbreviations
       fi
 
-      if ! [[ -f ${TMPDIR:-/tmp/}zsh-abbr/global-user-abbreviations ]]; then
-        touch ${TMPDIR:-/tmp/}zsh-abbr/global-user-abbreviations
+      if ! [[ -f ${ABBR_TMPDIR}global-user-abbreviations ]]; then
+        touch ${ABBR_TMPDIR}global-user-abbreviations
       fi
     }
 
@@ -1154,8 +1157,8 @@ _abbr_load_user_abbreviations() {
         touch $ABBR_USER_ABBREVIATIONS_FILE
       fi
 
-      typeset -p ABBR_REGULAR_USER_ABBREVIATIONS > ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations
-      typeset -p ABBR_GLOBAL_USER_ABBREVIATIONS > ${TMPDIR:-/tmp/}zsh-abbr/global-user-abbreviations
+      typeset -p ABBR_REGULAR_USER_ABBREVIATIONS > ${ABBR_TMPDIR}regular-user-abbreviations
+      typeset -p ABBR_GLOBAL_USER_ABBREVIATIONS > ${ABBR_TMPDIR}global-user-abbreviations
     }
 
     ABBR_LOADING_USER_ABBREVIATIONS=1

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -865,15 +865,15 @@ _abbr() {
       fi
     fi
 
-    if (( dry_run && ! ABBR_TESTING )); then
-      output+=$'\n'
-      output+="${warn_color}Dry run. Changes not saved.%f"
-    fi
-
     if (( has_error )); then
       [[ -n $output ]] && _abbr_print -P - $output >&2
       return 1
     else
+      if (( dry_run && ! ABBR_TESTING )); then
+        output+=$'\n'
+        output+="${warn_color}Dry run. Changes not saved.%f"
+      fi
+
       [[ -n $output ]] && _abbr_print -P - $output >&1
       return 0
     fi

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -8,24 +8,24 @@
 # -------------
 
 # Should `abbr-load` run before every `abbr` command? (default true)
-ABBR_AUTOLOAD=${ABBR_AUTOLOAD:-1}
+typeset -i ABBR_AUTOLOAD=${ABBR_AUTOLOAD:-1}
 
 # Log debugging messages?
-ABBR_DEBUG=${ABBR_DEBUG:-0}
+typeset -i ABBR_DEBUG=${ABBR_DEBUG:-0}
 
 # Whether to add default bindings (expand on SPACE, expand and accept on ENTER,
 # add CTRL for normal SPACE/ENTER; in incremental search mode expand on CTRL+SPACE)
 # (default true)
-ABBR_DEFAULT_BINDINGS=${ABBR_DEFAULT_BINDINGS:-1}
+typeset -i ABBR_DEFAULT_BINDINGS=${ABBR_DEFAULT_BINDINGS:-1}
 
 # Behave as if `--dry-run` was passed? (default false)
-ABBR_DRY_RUN=${ABBR_DRY_RUN:-0}
+typeset -i ABBR_DRY_RUN=${ABBR_DRY_RUN:-0}
 
 # Behave as if `--force` was passed? (default false)
-ABBR_FORCE=${ABBR_FORCE:-0}
+typeset -i ABBR_FORCE=${ABBR_FORCE:-0}
 
 # Behave as if `--quiet` was passed? (default false)
-ABBR_QUIET=${ABBR_QUIET:-0}
+typeset -i ABBR_QUIET=${ABBR_QUIET:-0}
 
 # File abbreviations are stored in
 ABBR_USER_ABBREVIATIONS_FILE=${ABBR_USER_ABBREVIATIONS_FILE:-$HOME/.config/zsh/abbreviations}
@@ -37,9 +37,10 @@ _abbr() {
   emulate -LR zsh
 
   {
-    local action dry_run error_color force has_error number_opts opt logs \
-          output quiet release_date scope should_exit success_color \
-          type version warn_color
+    local action error_color opt logs output release_date scope \
+      success_color type version warn_color
+    local -i dry_run force has_error number_opts quiet should_exit
+
     dry_run=$ABBR_DRY_RUN
     force=$ABBR_FORCE
     number_opts=0
@@ -429,7 +430,7 @@ _abbr() {
       local cmd
       local expansion
       local job_group
-      local success
+      local -a success
       local verb_phrase
 
       abbreviation=$1
@@ -886,12 +887,12 @@ _abbr() {
       fi
     fi
 
-    if (( dry_run )); then
+    if (( dry_run && ! ABBR_TESTING )); then
       output+=$'\n'
       output+="${warn_color}Dry run. Changes not saved.%f"
     fi
 
-    if [[ -n $has_error ]]; then
+    if (( $has_error )); then
       [[ -n $output ]] && _abbr_print -P - $output >&2
       return 1
     else
@@ -1141,7 +1142,7 @@ _abbr_load_user_abbreviations() {
       local abbreviation
       local arguments
       local program
-      local shwordsplit_on
+      local -i shwordsplit_on
       typeset -a user_abbreviations
 
       shwordsplit_on=0
@@ -1238,7 +1239,7 @@ _abbr_expand_widget() {
   local expansion
   local word
   local words
-  local word_count
+  local -i word_count
 
   words=(${(z)LBUFFER})
   word=$words[-1]

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -201,7 +201,7 @@ _abbr() {
 
       expansion=$(_abbr_cmd_expansion "$abbreviation")
 
-      if [ ! "$expansion" ]; then
+      if [[ ! "$expansion" ]]; then
         expansion=$(_abbr_global_expansion "$abbreviation")
       fi
       _abbr:util_print "${(Q)expansion}"
@@ -414,7 +414,7 @@ _abbr() {
         fi
       fi
 
-      if [ $expansion ]; then
+      if [[ $expansion ]]; then
         _abbr:util_add $new_abbreviation $expansion
         _abbr:erase $current_abbreviation
       else
@@ -532,7 +532,7 @@ _abbr() {
         fi
         alias_definition+="$abbreviation='$expansion'"
 
-        if [ $output_path ]; then
+        if [[ $output_path ]]; then
           _abbr_echo "$alias_definition" >> "$output_path"
         else
           print "$alias_definition"
@@ -558,7 +558,7 @@ _abbr() {
 
       message="$1 is deprecated and will be dropped in a future version."
 
-      if [ $new ]; then
+      if [[ $new ]]; then
         message+=" Please use $new instead."
       fi
 
@@ -671,11 +671,11 @@ _abbr() {
 
       result=$abbreviation
 
-      if [ $expansion ]; then
+      if [[ $expansion ]]; then
         result+="=${(qqq)${(Q)expansion}}"
       fi
 
-      if [ $prefix ]; then
+      if [[ $prefix ]]; then
         result="$prefix $result"
       fi
 
@@ -702,7 +702,7 @@ _abbr() {
       option=$1
       value=$2
 
-      if [ ${(P)option} ]; then
+      if [[ ${(P)option} ]]; then
         return
       fi
 
@@ -865,7 +865,7 @@ _abbr() {
         fi
       fi
 
-      if [ $action ]; then
+      if [[ $action ]]; then
         _abbr:$action $@
       elif [[ $# > 0 ]]; then
         # default if arguments are provided
@@ -933,7 +933,7 @@ _abbr_cmd_expansion() {
   abbreviation=$1
   expansion=${REGULAR_SESSION_ABBREVIATIONS[$abbreviation]}
 
-  if [ ! $expansion ]; then
+  if [[ ! $expansion ]]; then
     source ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations
     expansion=${REGULAR_USER_ABBREVIATIONS[$abbreviation]}
   fi
@@ -987,7 +987,7 @@ _abbr_global_expansion() {
   abbreviation=$1
   expansion=${GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]}
 
-  if [ ! $expansion ]; then
+  if [[ ! $expansion ]]; then
     source ${TMPDIR:-/tmp/}zsh-abbr/global-user-abbreviations
     expansion=${GLOBAL_USER_ABBREVIATIONS[$abbreviation]}
   fi
@@ -1039,7 +1039,7 @@ _abbr_job_push() {
     function _abbr_job_push:add_job() {
       (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
 
-      if ! [ -d $job_dir ]; then
+      if ! [[ -d $job_dir ]]; then
         mkdir -p $job_dir
       fi
 
@@ -1121,15 +1121,15 @@ _abbr_load_user_abbreviations() {
       REGULAR_USER_ABBREVIATIONS=()
       GLOBAL_USER_ABBREVIATIONS=()
 
-      if ! [ -d ${TMPDIR:-/tmp/}zsh-abbr ]; then
+      if ! [[ -d ${TMPDIR:-/tmp/}zsh-abbr ]]; then
         mkdir -p ${TMPDIR:-/tmp/}zsh-abbr
       fi
 
-      if ! [ -f ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations ]; then
+      if ! [[ -f ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations ]]; then
         touch ${TMPDIR:-/tmp/}zsh-abbr/regular-user-abbreviations
       fi
 
-      if ! [ -f ${TMPDIR:-/tmp/}zsh-abbr/global-user-abbreviations ]; then
+      if ! [[ -f ${TMPDIR:-/tmp/}zsh-abbr/global-user-abbreviations ]]; then
         touch ${TMPDIR:-/tmp/}zsh-abbr/global-user-abbreviations
       fi
     }
@@ -1150,7 +1150,7 @@ _abbr_load_user_abbreviations() {
       fi
 
       # Load saved user abbreviations
-      if [ -f $ABBR_USER_ABBREVIATIONS_FILE ]; then
+      if [[ -f $ABBR_USER_ABBREVIATIONS_FILE ]]; then
         unsetopt shwordsplit
 
         user_abbreviations=( ${(f)"$(<$ABBR_USER_ABBREVIATIONS_FILE)"} )
@@ -1243,7 +1243,7 @@ _abbr_expand_widget() {
     expansion=$(_abbr_cmd_expansion $word)
   fi
 
-  if [ ! $expansion ]; then
+  if [[ ! $expansion ]]; then
     expansion=$(_abbr_global_expansion $word)
   fi
 

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -8,27 +8,27 @@
 # -------------
 
 # Should `abbr-load` run before every `abbr` command? (default true)
-typeset -i ABBR_AUTOLOAD=${ABBR_AUTOLOAD:-1}
+typeset -gi ABBR_AUTOLOAD=${ABBR_AUTOLOAD:-1}
 
 # Log debugging messages?
-typeset -i ABBR_DEBUG=${ABBR_DEBUG:-0}
+typeset -gi ABBR_DEBUG=${ABBR_DEBUG:-0}
 
 # Whether to add default bindings (expand on SPACE, expand and accept on ENTER,
 # add CTRL for normal SPACE/ENTER; in incremental search mode expand on CTRL+SPACE)
 # (default true)
-typeset -i ABBR_DEFAULT_BINDINGS=${ABBR_DEFAULT_BINDINGS:-1}
+typeset -gi ABBR_DEFAULT_BINDINGS=${ABBR_DEFAULT_BINDINGS:-1}
 
 # Behave as if `--dry-run` was passed? (default false)
-typeset -i ABBR_DRY_RUN=${ABBR_DRY_RUN:-0}
+typeset -gi ABBR_DRY_RUN=${ABBR_DRY_RUN:-0}
 
 # Behave as if `--force` was passed? (default false)
-typeset -i ABBR_FORCE=${ABBR_FORCE:-0}
+typeset -gi ABBR_FORCE=${ABBR_FORCE:-0}
 
 # Behave as if `--quiet` was passed? (default false)
-typeset -i ABBR_QUIET=${ABBR_QUIET:-0}
+typeset -gi ABBR_QUIET=${ABBR_QUIET:-0}
 
 # File abbreviations are stored in
-ABBR_USER_ABBREVIATIONS_FILE=${ABBR_USER_ABBREVIATIONS_FILE:-$HOME/.config/zsh/abbreviations}
+typeset -g ABBR_USER_ABBREVIATIONS_FILE=${ABBR_USER_ABBREVIATIONS_FILE:-$HOME/.config/zsh/abbreviations}
 
 # FUNCTIONS
 # ---------

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -886,8 +886,8 @@ _abbr() {
       fi
 
       if (( dry_run )); then
-        logs+=$'\n'
-        logs+="${warn_color}Dry run. Changes not saved.%f"
+        output+=$'\n'
+        output+="${warn_color}Dry run. Changes not saved.%f"
       fi
     fi
 

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -48,9 +48,9 @@ _abbr() {
     version="zsh-abbr version 3.3.4"
 
     if ! (( ${+NO_COLOR} )); then
-      error_color="red"
-      success_color="green"
-      warn_color="yellow"
+      error_color="%F{red}"
+      success_color="%F{green}"
+      warn_color="%F{yellow}"
     fi
 
     if (( ABBR_LOADING_USER_ABBREVIATIONS )); then
@@ -169,12 +169,12 @@ _abbr() {
           fi
         fi
 
-        _abbr:util_log "${success_color:+%F{$success_color}}$verb_phrase%f ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\`"
+        _abbr:util_log "${success_color}$verb_phrase%f ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\`"
       else
         verb_phrase="Did not erase"
         (( dry_run )) && verb_phrase="Would not erase"
 
-        message="${error_color:+%F{$error_color}}$verb_phrase%f abbreviation \`$abbreviation\`. Please specify one of"
+        message="${error_color}$verb_phrase%f abbreviation \`$abbreviation\`. Please specify one of"
         message=$'\n'
 
         for abbreviations_set in ${abbreviations_sets[@]}; do
@@ -504,7 +504,7 @@ _abbr() {
         verb_phrase="Added"
         (( dry_run )) && verb_phrase="Would add"
 
-        _abbr:util_log "${success_color:+%F{$success_color}}$verb_phrase%f the ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\`"
+        _abbr:util_log "${success_color}$verb_phrase%f the ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\`"
       else
         verb_phrase="was not added"
         (( dry_run )) && verb_phrase="would not be added"
@@ -569,7 +569,7 @@ _abbr() {
       (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
       has_error=1
-      logs+=${logs:+$'\n'}"${error_color:+%F{$error_color}}$@%f"
+      logs+=${logs:+$'\n'}"${error_color}$@%f"
       should_exit=1
     }
 
@@ -745,7 +745,7 @@ _abbr() {
     _abbr:util_warn() {
       (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
-      logs+=${logs:+'\n'}"${warn_color:+%F{$warn_color}}$@%f"
+      logs+=${logs:+'\n'}"${warn_color}$@%f"
     }
 
     for opt in "$@"; do
@@ -887,7 +887,7 @@ _abbr() {
 
       if (( dry_run )); then
         logs+=$'\n'
-        logs+="${warn_color:+%F{$warn_color}}Dry run. Changes not saved.%f"
+        logs+="${warn_color}Dry run. Changes not saved.%f"
       fi
     fi
 

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -1034,53 +1034,21 @@ _abbr_global_expansion() {
 _abbr_init() {
   emulate -LR zsh
 
-  {
-    (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+  local job
 
-    local job
+  typeset -gA REGULAR_USER_ABBREVIATIONS
+  typeset -gA GLOBAL_USER_ABBREVIATIONS
+  typeset -gA REGULAR_SESSION_ABBREVIATIONS
+  typeset -gA GLOBAL_SESSION_ABBREVIATIONS
 
-    typeset -gA REGULAR_USER_ABBREVIATIONS
-    typeset -gA GLOBAL_USER_ABBREVIATIONS
-    typeset -gA REGULAR_SESSION_ABBREVIATIONS
-    typeset -gA GLOBAL_SESSION_ABBREVIATIONS
+  job=$(_abbr_job_name)
+  REGULAR_SESSION_ABBREVIATIONS=()
+  GLOBAL_SESSION_ABBREVIATIONS=()
 
-    function _abbr_init:clean() {
-      (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
-
-      # clean up deprecated temp files
-
-      if [ -d ${TMPDIR:-/tmp/}zsh-abbr-jobs ]; then
-        rm -rf ${TMPDIR:-/tmp/}zsh-abbr-jobs 2> /dev/null
-      fi
-
-      if [ -f ${TMPDIR:-/tmp/}zsh-user-global-abbreviations ]; then
-        rm ${TMPDIR:-/tmp/}zsh-user-global-abbreviations 2> /dev/null
-      fi
-
-      if [ -f ${TMPDIR:-/tmp/}zsh-user-abbreviations ]; then
-        rm ${TMPDIR:-/tmp/}zsh-user-abbreviations 2> /dev/null
-      fi
-
-      if [ -f ${TMPDIR:-/tmp/}zsh-abbr-initializing ]; then
-        rm ${TMPDIR:-/tmp/}zsh-abbr-initializing
-      fi
-
-      if [ -f ${TMPDIR:-/tmp/}abbr_universals ]; then
-        rm ${TMPDIR:-/tmp/}abbr_universals
-      fi
-    }
-
-    job=$(_abbr_job_name)
-    REGULAR_SESSION_ABBREVIATIONS=()
-    GLOBAL_SESSION_ABBREVIATIONS=()
-
-    _abbr_job_push $job initialization
-    _abbr_init:clean
-    _abbr_load_user_abbreviations
-    _abbr_job_pop $job
-  } always {
-    unfunction -m _abbr_init:clean
-  }
+  _abbr_job_push $job initialization
+  (( ABBR_DEBUG )) && _abbr_echo $funcstack[1]
+  _abbr_load_user_abbreviations
+  _abbr_job_pop $job
 }
 
 _abbr_job_push() {

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -215,12 +215,10 @@ _abbr() {
       _abbr_debugger
 
       local type_saved
-      local output_path
 
       type_saved=$type
-      output_path=$1
 
-      if [[ $# > 1 ]]; then
+      if [[ $# > 0 ]]; then
         _abbr:util_error "abbr export-aliases: Unexpected argument"
         return
       fi
@@ -523,24 +521,19 @@ _abbr() {
       local abbreviation
       local abbreviations_set
       local expansion
-      local output_path
 
       abbreviations_set=$1
-      output_path=$2
 
       for abbreviation in ${(iko)${(P)abbreviations_set}}; do
-        alias_definition="alias "
         expansion=${${(P)abbreviations_set}[$abbreviation]}
+
+        alias_definition="alias "
         if [[ $type == 'global' ]]; then
           alias_definition+="-g "
         fi
         alias_definition+="$abbreviation='$expansion'"
 
-        if [[ $output_path ]]; then
-          _abbr_echo "$alias_definition" >> "$output_path"
-        else
-          print "$alias_definition"
-        fi
+        print "$alias_definition"
       done
     }
 

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -884,11 +884,11 @@ _abbr() {
       if [[ -n $logs ]]; then
         output=$logs${output:+$'\n'$output}
       fi
+    fi
 
-      if (( dry_run )); then
-        output+=$'\n'
-        output+="${warn_color}Dry run. Changes not saved.%f"
-      fi
+    if (( dry_run )); then
+      output+=$'\n'
+      output+="${warn_color}Dry run. Changes not saved.%f"
     fi
 
     if [[ -n $has_error ]]; then

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -775,15 +775,12 @@ _abbr() {
           ;;
         "import-aliases")
           _abbr:util_set_once action import_aliases
-          importing=1
           ;;
         "import-fish")
           _abbr:util_set_once action import_fish
-          importing=1
           ;;
         "import-git-aliases")
           _abbr:util_set_once action import_git_aliases
-          importing=1
           ;;
         "list")
           _abbr:util_set_once action list

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -547,25 +547,6 @@ _abbr() {
       _abbr:util_error "abbr: Illegal combination of options"
     }
 
-    _abbr:util_deprecated() {
-      (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
-
-      local message
-      local new
-      local old
-
-      old=$1
-      new=$2
-
-      message="$1 is deprecated and will be dropped in a future version."
-
-      if [[ $new ]]; then
-        message+=" Please use $new instead."
-      fi
-
-      _abbr:util_warn $message
-    }
-
     _abbr:util_error() {
       (( ABBR_DEBUG )) && _abbr_print $funcstack[1]
 
@@ -941,17 +922,6 @@ _abbr_cmd_expansion() {
   fi
 
   _abbr_echo - $expansion
-}
-
-_abbr_deprecated() {
-  emulate -LR zsh
-  local message
-
-  message="$1 is deprecated. Please use $2 instead."
-  if ! (( ${+NO_COLOR} )); then
-    message="%F{yellow}$message%f"
-  fi
-  _abbr_print $message
 }
 
 _abbr_expand_and_accept() {

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -1115,6 +1115,8 @@ _abbr_load_user_abbreviations() {
       local -i shwordsplit_on
       typeset -a user_abbreviations
 
+      typeset -gi ABBR_LOADING_USER_ABBREVIATIONS
+
       shwordsplit_on=0
 
       if [[ $options[shwordsplit] = on ]]; then
@@ -1151,12 +1153,9 @@ _abbr_load_user_abbreviations() {
     }
 
     ABBR_LOADING_USER_ABBREVIATIONS=1
-
     _abbr_load_user_abbreviations:setup
     _abbr_load_user_abbreviations:load
-
-    ABBR_LOADING_USER_ABBREVIATIONS=0
-
+    unset ABBR_LOADING_USER_ABBREVIATIONS
     return
   } always {
     unfunction -m _abbr_load_user_abbreviations:setup

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -860,15 +860,14 @@ _abbr() {
     fi
 
     if (( has_error )); then
-      [[ -n $output ]] && _abbr_print -P - $output >&2
+      [[ -n $output ]] && _abbr_echo - $output >&2
       return 1
     else
       if (( dry_run && ! ABBR_TESTING )); then
-        output+=$'\n'
         output+="\\n${warn_color}Dry run. Changes not saved.$reset_color"
       fi
 
-      [[ -n $output ]] && _abbr_print -P - $output >&1
+      [[ -n $output ]] && _abbr_echo - $output >&1
       return 0
     fi
   }
@@ -921,7 +920,7 @@ _abbr_debugger() {
   # user abbreviations are loaded on every git subcommand, making noise
   (( ABBR_LOADING_USER_ABBREVIATIONS && ! ABBR_INITIALIZING )) && return
 
-  (( ABBR_DEBUG )) && _abbr_print $funcstack[2]
+  (( ABBR_DEBUG )) && _abbr_echo - $funcstack[2]
 }
 
 _abbr_expand_and_accept() {
@@ -1029,11 +1028,11 @@ _abbr_job_push() {
 
       next_job_path=$job_dir/$next_job
 
-      _abbr_print "abbr: A job added at $(strftime '%T %b %d %Y' ${next_job%.*}) has timed out."
-      _abbr_print "The job was related to $(cat $next_job_path)."
-      _abbr_print "This could be the result of manually terminating an abbr activity, for example during session startup."
-      _abbr_print "If you believe it reflects a abbr bug, please report it at https://github.com/olets/zsh-abbr/issues/new"
-      _abbr_print
+      _abbr_echo "abbr: A job added at $(strftime '%T %b %d %Y' ${next_job%.*}) has timed out."
+      _abbr_echo "The job was related to $(cat $next_job_path)."
+      _abbr_echo "This could be the result of manually terminating an abbr activity, for example during session startup."
+      _abbr_echo "If you believe it reflects a abbr bug, please report it at https://github.com/olets/zsh-abbr/issues/new"
+      _abbr_echo
 
       rm $next_job_path &>/dev/null
     }
@@ -1192,10 +1191,6 @@ _abbr_wrap_external_commands() {
 
   _abbr_man() {
     'command' 'man' $@
-  }
-
-  _abbr_print() {
-    'builtin' 'print' $@
   }
 }
 

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -38,15 +38,13 @@ _abbr() {
 
   {
     local action dry_run error_color force has_error number_opts opt logs \
-          output quiet release_date scope should_exit success_color text_bold \
-          text_reset type version warn_color
+          output quiet release_date scope should_exit success_color \
+          type version warn_color
     dry_run=$ABBR_DRY_RUN
     force=$ABBR_FORCE
     number_opts=0
     quiet=$ABBR_QUIET
     release_date="July 26 2020"
-    text_bold="\\033[1m"
-    text_reset="\\033[0m"
     version="zsh-abbr version 3.3.4"
 
     if ! (( ${+NO_COLOR} )); then
@@ -1274,7 +1272,7 @@ abbr() {
 # INITIALIZATION
 # --------------
 
-autoload -U colors && colors
+! (( ${+NO_COLOR} )) && autoload -U colors && colors
 ABBR_SOURCE_PATH=${0:A:h}
 _abbr_wrap_external_commands
 _abbr_init

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -52,9 +52,9 @@ _abbr() {
     version="zsh-abbr version 3.3.4"
 
     if ! (( ${+NO_COLOR} )); then
-      error_color="%F{red}"
-      success_color="%F{green}"
-      warn_color="%F{yellow}"
+      error_color="red"
+      success_color="green"
+      warn_color="yellow"
     fi
 
     if (( ABBR_LOADING_USER_ABBREVIATIONS )); then
@@ -173,12 +173,12 @@ _abbr() {
           fi
         fi
 
-        _abbr:util_log "${success_color}$verb_phrase%f ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\`"
+        _abbr:util_log "${success_color:+%F{$success_color}}$verb_phrase%f ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\`"
       else
         verb_phrase="Did not erase"
         (( dry_run )) && verb_phrase="Would not erase"
 
-        message="${error_color}$verb_phrase%f abbreviation \`$abbreviation\`. Please specify one of"
+        message="${error_color:+%F{$error_color}}$verb_phrase%f abbreviation \`$abbreviation\`. Please specify one of"
         message=$'\n'
 
         for abbreviations_set in ${abbreviations_sets[@]}; do
@@ -506,7 +506,7 @@ _abbr() {
         verb_phrase="Added"
         (( dry_run )) && verb_phrase="Would add"
 
-        _abbr:util_log "${success_color}$verb_phrase%f the ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\`"
+        _abbr:util_log "${success_color:+%F{$success_color}}$verb_phrase%f the ${type:-regular} ${scope:-user} abbreviation \`$abbreviation\`"
       else
         verb_phrase="Did not"
         (( dry_run )) && verb_phrase="Would not"
@@ -547,7 +547,7 @@ _abbr() {
       _abbr_debugger
 
       has_error=1
-      logs+=${logs:+$'\n'}"${error_color}$@%f"
+      logs+=${logs:+$'\n'}"${error_color:+%F{$error_color}}$@%f"
       should_exit=1
     }
 
@@ -723,7 +723,7 @@ _abbr() {
     _abbr:util_warn() {
       _abbr_debugger
 
-      logs+=${logs:+'\n'}"${warn_color}$@%f"
+      logs+=${logs:+'\n'}"${warn_color:+%F{$warn_color}}$@%f"
     }
 
     for opt in "$@"; do

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -8,27 +8,27 @@
 # -------------
 
 # Should `abbr-load` run before every `abbr` command? (default true)
-ABBR_AUTOLOAD=${ABBR_AUTOLOAD:-${ZSH_ABBR_AUTOLOAD:-1}}
+ABBR_AUTOLOAD=${ABBR_AUTOLOAD:-1}
 
 # Log debugging messages?
-ABBR_DEBUG=${ABBR_DEBUG:-${ZSH_ABBR_DEBUG:-0}}
+ABBR_DEBUG=${ABBR_DEBUG:-0}
 
 # Whether to add default bindings (expand on SPACE, expand and accept on ENTER,
 # add CTRL for normal SPACE/ENTER; in incremental search mode expand on CTRL+SPACE)
 # (default true)
-ABBR_DEFAULT_BINDINGS=${ABBR_DEFAULT_BINDINGS:-${ZSH_ABBR_DEFAULT_BINDINGS:-1}}
+ABBR_DEFAULT_BINDINGS=${ABBR_DEFAULT_BINDINGS:-1}
 
 # Behave as if `--dry-run` was passed? (default false)
-ABBR_DRY_RUN=${ABBR_DRY_RUN:-${ZSH_ABBR_DRY_RUN:-0}}
+ABBR_DRY_RUN=${ABBR_DRY_RUN:-0}
 
 # Behave as if `--force` was passed? (default false)
-ABBR_FORCE=${ABBR_FORCE:-${ZSH_ABBR_FORCE:-0}}
+ABBR_FORCE=${ABBR_FORCE:-0}
 
 # Behave as if `--quiet` was passed? (default false)
-ABBR_QUIET=${ABBR_QUIET:-${ZSH_ABBR_QUIET:-0}}
+ABBR_QUIET=${ABBR_QUIET:-0}
 
 # File abbreviations are stored in
-ABBR_USER_ABBREVIATIONS_FILE=${ABBR_USER_ABBREVIATIONS_FILE:-${ABBR_USER_PATH:-${ZSH_ABBR_USER_PATH:-$HOME/.config/zsh/abbreviations}}}
+ABBR_USER_ABBREVIATIONS_FILE=${ABBR_USER_ABBREVIATIONS_FILE:-$HOME/.config/zsh/abbreviations}
 
 # FUNCTIONS
 # ---------
@@ -53,17 +53,6 @@ _abbr() {
       error_color="$fg[red]"
       success_color="$fg[green]"
       warn_color="$fg[yellow]"
-    fi
-
-    # Deprecation notices for values that could be meaningfully set after initialization
-    if ! (( ABBR_LOADING_USER_ABBREVIATIONS )); then
-      (( ${+ZSH_ABBR_AUTOLOAD} )) && _abbr_deprecated ZSH_ABBR_AUTOLOAD ABBR_AUTOLOAD
-      (( ${+ZSH_ABBR_DEBUG} )) && _abbr_deprecated ZSH_ABBR_DEBUG ABBR_DEBUG
-      (( ${+ZSH_ABBR_DRY_RUN} )) && _abbr_deprecated ZSH_ABBR_DRY_RUN ABBR_DRY_RUN
-      (( ${+ZSH_ABBR_FORCE} )) && _abbr_deprecated ZSH_ABBR_FORCE ABBR_FORCE
-      (( ${+ZSH_ABBR_QUIET} )) && _abbr_deprecated ZSH_ABBR_QUIET ABBR_QUIET
-      (( ${+ZSH_ABBR_USER_PATH} )) && _abbr_deprecated ZSH_ABBR_USER_PATH ABBR_USER_ABBREVIATIONS_FILE
-      (( ${+ABBR_USER_PATH} )) && _abbr_deprecated ABBR_USER_PATH ABBR_USER_ABBREVIATIONS_FILE
     fi
 
     if (( ABBR_LOADING_USER_ABBREVIATIONS )); then
@@ -1349,76 +1338,6 @@ abbr() {
 # DEPRECATION
 # -----------
 
-# Deprecation notices for values that could not be meaningfully set after initialization
-(( ${+ZSH_ABBR_DEFAULT_BINDINGS} )) && _abbr_deprecated ZSH_ABBR_DEFAULT_BINDINGS ABBR_DEFAULT_BINDINGS
-[ $ABBR_DEFAULT_BINDINGS = true ] && _abbr_deprecated "String value (\`true\` and \`false\`) ABBR_DEFAULT_BINDINGS" "Boolean value (\`0\` and \`1\`)"
-
-# Deprecation notices for functions
-_zsh_abbr() {
-  _abbr_deprecated _zsh_abbr _abbr
-  _abbr
-}
-
-_zsh_abbr_bind_widgets() {
-  _abbr_deprecated _zsh_abbr_bind_widgets _abbr_bind_widgets
-  _abbr_bind_widgets
-}
-
-_zsh_abbr_cmd_expansion() {
-  _abbr_deprecated _zsh_abbr_cmd_expansion _abbr_cmd_expansion
-  _abbr_cmd_expansion
-}
-
-_zsh_abbr_expand_and_accept() {
-  _abbr_deprecated _zsh_abbr_expand_and_accept _abbr_expand_and_accept
-  _abbr_expand_and_accept
-}
-
-_zsh_abbr_expand_and_space() {
-  _abbr_deprecated _zsh_abbr_expand_and_space _abbr_expand_and_space
-  _abbr_expand_and_space
-}
-
-_zsh_abbr_global_expansion() {
-  _abbr_deprecated _zsh_abbr_global_expansion _abbr_global_expansion
-  _abbr_global_expansion
-}
-
-_zsh_abbr_init() {
-  _abbr_deprecated _zsh_abbr_init _abbr_init
-  _abbr_init
-}
-
-_zsh_abbr_job_push() {
-  _abbr_deprecated _zsh_abbr_job_push _abbr_job_push
-  _abbr_job_push
-}
-
-_zsh_abbr_job_pop() {
-  _abbr_deprecated _zsh_abbr_job_pop _abbr_job_pop
-  _abbr_job_pop
-}
-
-_zsh_abbr_job_name() {
-  _abbr_deprecated _zsh_abbr_job_name _abbr_job_name
-  _abbr_job_name
-}
-
-_zsh_abbr_load_user_abbreviations() {
-  _abbr_deprecated _zsh_abbr_load_user_abbreviations _abbr_load_user_abbreviations
-  _abbr_load_user_abbreviations
-}
-
-_zsh_abbr_wrap_external_commands() {
-  _abbr_deprecated _zsh_abbr_wrap_external_commands _abbr_wrap_external_commands
-  _abbr_wrap_external_commands
-}
-
-_zsh_abbr_expand_widget() {
-  _abbr_deprecated _zsh_abbr_expand_widget _abbr_expand_widget
-  _abbr_expand_widget
-}
-
 
 # INITIALIZATION
 # --------------
@@ -1427,6 +1346,4 @@ autoload -U colors && colors
 ABBR_SOURCE_PATH=${0:A:h}
 _abbr_wrap_external_commands
 _abbr_init
-if (( $ABBR_DEFAULT_BINDINGS )) || [ $ABBR_DEFAULT_BINDINGS = true ]; then
-  _abbr_bind_widgets
-fi
+(( $ABBR_DEFAULT_BINDINGS )) &&  _abbr_bind_widgets

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -331,6 +331,21 @@ _abbr() {
     _abbr:list() {
       _abbr_debugger
 
+      local -i include_expansion
+
+      if [[ $# > 0 ]]; then
+        _abbr:util_error "abbr list definitions: Unexpected argument"
+        return
+      fi
+
+      include_expansion=1
+
+      _abbr:util_list $include_expansion
+    }
+
+    _abbr:list_abbreviations() {
+      _abbr_debugger
+
       if [[ $# > 0 ]]; then
         _abbr:util_error "abbr list: Unexpected argument"
         return
@@ -356,21 +371,6 @@ _abbr() {
       user_prefix=abbr
 
       _abbr:util_list $include_expansion $session_prefix $user_prefix
-    }
-
-    _abbr:list_abbreviations() {
-      _abbr_debugger
-
-      local -i include_expansion
-
-      if [[ $# > 0 ]]; then
-        _abbr:util_error "abbr list definitions: Unexpected argument"
-        return
-      fi
-
-      include_expansion=1
-
-      _abbr:util_list $include_expansion
     }
 
     _abbr:print_version() {
@@ -851,7 +851,7 @@ _abbr() {
         _abbr:add $@
       else
         # default if no argument is provided
-        _abbr:list_abbreviations $@
+        _abbr:list $@
       fi
     fi
 

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -342,7 +342,7 @@ _abbr() {
     _abbr:list_commands() {
       _abbr_debugger
 
-      local include_expansion
+      local -i include_expansion
       local session_prefix
       local user_prefix
 
@@ -361,7 +361,7 @@ _abbr() {
     _abbr:list_abbreviations() {
       _abbr_debugger
 
-      local include_expansion
+      local -i include_expansion
 
       if [[ $# > 0 ]]; then
         _abbr:util_error "abbr list definitions: Unexpected argument"
@@ -599,7 +599,7 @@ _abbr() {
 
       local abbreviation
       local expansion
-      local include_expansion
+      local -i include_expansion
       local session_prefix
       local user_prefix
 
@@ -610,14 +610,14 @@ _abbr() {
       if [[ $scope != 'session' ]]; then
         if [[ $type != 'regular' ]]; then
           for abbreviation in ${(iko)ABBR_GLOBAL_USER_ABBREVIATIONS}; do
-            expansion=${include_expansion:+${ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]}}
+            (( include_expansion )) && expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]}
             _abbr:util_list_item $abbreviation $expansion ${user_prefix:+$user_prefix -g}
           done
         fi
 
         if [[ $type != 'global' ]]; then
           for abbreviation in ${(iko)ABBR_REGULAR_USER_ABBREVIATIONS}; do
-            expansion=${include_expansion:+${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]}}
+            (( include_expansion )) && expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]}
             _abbr:util_list_item $abbreviation $expansion $user_prefix
           done
         fi
@@ -626,14 +626,14 @@ _abbr() {
       if [[ $scope != 'user' ]]; then
         if [[ $type != 'regular' ]]; then
           for abbreviation in ${(iko)ABBR_GLOBAL_SESSION_ABBREVIATIONS}; do
-            expansion=${include_expansion:+${ABBR_GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]}}
+            (( include_expansion )) && expansion=${ABBR_GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]}
             _abbr:util_list_item $abbreviation $expansion ${session_prefix:+$session_prefix -g}
           done
         fi
 
         if [[ $type != 'global' ]]; then
           for abbreviation in ${(iko)ABBR_REGULAR_SESSION_ABBREVIATIONS}; do
-            expansion=${include_expansion:+${ABBR_REGULAR_SESSION_ABBREVIATIONS[$abbreviation]}}
+            (( include_expansion )) && expansion=${ABBR_REGULAR_SESSION_ABBREVIATIONS[$abbreviation]}
             _abbr:util_list_item $abbreviation $expansion $session_prefix
           done
         fi

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -927,6 +927,9 @@ _abbr_cmd_expansion() {
 _abbr_debugger() {
   emulate -LR zsh
 
+  # user abbreviations are loaded on every git subcommand, making noise
+  (( ABBR_LOADING_USER_ABBREVIATIONS && ! ABBR_INITIALIZING )) && return
+
   (( ABBR_DEBUG )) && _abbr_print $funcstack[2]
 }
 
@@ -1255,8 +1258,10 @@ abbr() {
 # INITIALIZATION
 # --------------
 
+typeset -i ABBR_INITIALIZING=1
 ! (( ${+NO_COLOR} )) && autoload -U colors && colors
 ABBR_SOURCE_PATH=${0:A:h}
 _abbr_wrap_external_commands
 _abbr_init
 (( ABBR_DEFAULT_BINDINGS )) &&  _abbr_bind_widgets
+unset ABBR_INITIALIZING

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -873,7 +873,7 @@ _abbr() {
       output+="${warn_color}Dry run. Changes not saved.%f"
     fi
 
-    if (( $has_error )); then
+    if (( has_error )); then
       [[ -n $output ]] && _abbr_print -P - $output >&2
       return 1
     else
@@ -1253,4 +1253,4 @@ abbr() {
 ABBR_SOURCE_PATH=${0:A:h}
 _abbr_wrap_external_commands
 _abbr_init
-(( $ABBR_DEFAULT_BINDINGS )) &&  _abbr_bind_widgets
+(( ABBR_DEFAULT_BINDINGS )) &&  _abbr_bind_widgets


### PR DESCRIPTION
Major release because of breaking changes:
- variable names changed
- deprecated functions no longer supported
- deprecated variables no longer supported
- what was `list` is now `list-abbreviations`; what was `list-abbreviations` is now `list` (default behavior when `abbr` is run without arguments remains the same)