### PR TITLE
Respect multiline Git aliases

### DIFF
--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -309,7 +309,7 @@ _abbr() {
       fi
 
       typeset -a git_aliases
-      git_aliases=( ${(f)"$(git config --get-regexp '^alias\.')"} )
+      git_aliases=( ${(ps|\nalias.|)"$(git config --get-regexp '^alias\.')"} )
 
       for git_alias in $git_aliases; do
         key=${${git_alias%% *}#alias.}


### PR DESCRIPTION
It is possible to define a Git alias that contains line breaks. Previously, this would result in zsh-abbr attempting to parse each
individual line as if it were a separate alias, resulting in lots of errors. The cause of this was splitting the output of `git config --get-regexp` on line breaks.

This change splits the output of `git config --get-regexp` on newlines followed by the string "alias.", thereby ensuring that an alias that takes multiple lines gets treated as a unit.

Unfortunately this splitting doesn't get rid of the prefix "alias." on the very first alias, and so we need to retain the substitution that gets rid of this prefix.

Resolves #30.