### PR TITLE
Make sure "rm" is run as command and not as alias

### DIFF
--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -1107,7 +1107,7 @@ _abbr_job_push() {
       'builtin' 'echo' "If you believe it reflects a abbr bug, please report it at https://github.com/olets/zsh-abbr/issues/new"
       'builtin' 'echo'
 
-      rm $next_job_path &>/dev/null
+      'command' 'rm' $next_job_path &>/dev/null
     }
 
     function _abbr_job_push:wait_turn() {


### PR DESCRIPTION
Make sure "rm" is run as command and not as alias. This is done so the terminal initialization doesn't hang in a prompt if "rm" is actually alias'd to "rm -i"