### PR TITLE
Omit the command existence check if both --force and --check are specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ zsh-abbr has commands to add, rename, and erase abbreviations; to add abbreviati
 - **`add`**
 
   ```shell
-  abbr [(add | -a)] [<SCOPE>] [<TYPE>] [--dry-run] [--quiet] [--force] ABBREVIATION=EXPANSION
+  abbr [(add | -a)] [<SCOPE>] [<TYPE>] [--dry-run] [(--quiet | --quieter)] [--force] ABBREVIATION=EXPANSION
   ```
 
   Add a new abbreviation.
@@ -166,7 +166,7 @@ zsh-abbr has commands to add, rename, and erase abbreviations; to add abbreviati
 
   Will error rather than overwrite an existing abbreviation.
 
-  Will warn if the abbreviation would replace an existing command. To add in spite of the warning, use `--force`.
+  Will warn if the abbreviation would replace an existing command. To add in spite of the warning, use `--force`. To silence the warning, use `--quieter`.
 
 - **`clear-session`**
 
@@ -403,7 +403,7 @@ zsh-abbr has commands to add, rename, and erase abbreviations; to add abbreviati
 - **`rename`**
 
   ```shell
-  abbr (rename | R) [<SCOPE>] [<TYPE>] [--dry-run] [--quiet] OLD NEW
+  abbr (rename | R) [<SCOPE>] [<TYPE>] [--dry-run] [(--quiet | --quieter)] OLD NEW
   ```
 
   Rename an abbreviation.
@@ -427,6 +427,8 @@ zsh-abbr has commands to add, rename, and erase abbreviations; to add abbreviati
 
   Abbreviations can also be manually renamed in the `ABBR_USER_ABBREVIATIONS_FILE`. See **Storage** below.
 
+  Conflicts will error or warn. See **add** for details.
+
 ## Advanced
 
 ### Configuration variables
@@ -442,6 +444,7 @@ Variable | Type | Use | Default
 `ABBR_FORCE` | integer | If non-zero, use force mode without passing `--force` (see [`add`](#add)) | 0
 `ABBR_PRECMD_LOGS` | interger | If non-zero, support precmd logs, for example to warn that a deprecated widget was used | 1
 `ABBR_QUIET` | integer | If non-zero, use quiet mode without passing `--quiet` | 0
+`ABBR_QUIETER` | integer | If non-zero, use quieter mode without passing `--quieter` | 0
 `ABBR_TMPDIR` | String | Path to the directory temporary files are stored in. _Ends in `/`_ | `${TMPDIR:-/tmp/}zsh-abbr/}` *
 `ABBR_USER_ABBREVIATIONS_FILE` | String | Path to the file user abbreviation are stored in (see [Storage and manual editing](#storage-and-manual-editing)) | `$HOME/.config/zsh/abbreviations` **
 

--- a/man/man1/abbr.1
+++ b/man/man1/abbr.1
@@ -159,8 +159,12 @@ All except for \fBclear-session\fR, \fBexpand\fR, \fBexport-aliases\fR, \fBlist-
 .RS
 
 .IP \(bu
-\fB\-\-quiet\fR
+\fB\-\-quiet\fR | \fB\-q\fR
 Do not log success, warning, or error messages.
+
+.IP \(bu
+\fB\-\-quieter\fR | \fB\-qq\fR
+Silence the warning that a newly-created abbreviation conflicts with a command name.
 
 .SH Configuration
 The following variables may be set:

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -619,6 +619,10 @@ _abbr() {
       # Warn if abbreviation would interfere with system command use, e.g. `cp="git cherry-pick"`
       # Apply force to add regardless
       if ! (( ABBR_LOADING_USER_ABBREVIATIONS )); then
+        if (( force && quiet )); then
+          return 0
+        fi
+
         cmd=$('builtin' 'command' -v $abbreviation)
 
         if [[ $cmd && ${cmd:0:6} != 'alias ' ]]; then

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -30,6 +30,9 @@ typeset -gi ABBR_PRECMD_LOGS=${ABBR_PRECMD_LOGS:-1}
 # Behave as if `--quiet` was passed? (default false)
 typeset -gi ABBR_QUIET=${ABBR_QUIET:-0}
 
+# Behave as if `--quieter` was passed? (default false)
+typeset -gi ABBR_QUIETER=${ABBR_QUIETER:-0}
+
 # Temp files are stored in
 typeset -g ABBR_TMPDIR=${ABBR_TMPDIR:-${${TMPDIR:-/tmp}%/}/zsh-abbr/}
 
@@ -43,14 +46,16 @@ _abbr() {
   emulate -LR zsh
 
   {
-    local action error_color job_name logs opt output release_date scope \
-      success_color type version warn_color
-    local -i dry_run force has_error number_opts quiet should_exit
+    local action error_color job_name logs_silent_when_quiet logs_silent_when_quieter \
+      opt output release_date scope success_color type version warn_color
+    local -i dry_run force has_error number_opts quiet quieter should_exit
 
     dry_run=$ABBR_DRY_RUN
     force=$ABBR_FORCE
     number_opts=0
     quiet=$ABBR_QUIET
+    quiet=$(( ABBR_QUIETER || ABBR_QUIET ))
+    quieter=$ABBR_QUIETER
     release_date="July 30 2021"
     version="zsh-abbr version 4.4.0"
 
@@ -67,6 +72,7 @@ _abbr() {
 
     if (( ABBR_LOADING_USER_ABBREVIATIONS )); then
       quiet=1
+      quieter=1
     fi
 
     _abbr:add() {
@@ -181,7 +187,7 @@ _abbr() {
           fi
         fi
 
-        _abbr:util_log "$success_color$verb_phrase$reset_color $(_abbr:util_set_to_typed_scope $abbreviations_sets) \`$abbreviation\`"
+        _abbr:util_log_unless_quiet "$success_color$verb_phrase$reset_color $(_abbr:util_set_to_typed_scope $abbreviations_sets) \`$abbreviation\`"
       else
         verb_phrase="Did not erase"
         (( dry_run )) && verb_phrase="Would not erase"
@@ -535,7 +541,7 @@ _abbr() {
         verb_phrase="Added"
         (( dry_run )) && verb_phrase="Would add"
 
-        _abbr:util_log "$success_color$verb_phrase$reset_color the $typed_scope \`$abbreviation\`"
+        _abbr:util_log_unless_quiet "$success_color$verb_phrase$reset_color the $typed_scope \`$abbreviation\`"
       else
         verb_phrase="Did not"
         (( dry_run )) && verb_phrase="Would not"
@@ -595,7 +601,7 @@ _abbr() {
       _abbr_debugger
 
       has_error=1
-      logs+="${logs:+\\n}$error_color$@$reset_color"
+      logs_silent_when_quiet+="${logs_silent_when_quiet:+\\n}$error_color$@$reset_color"
       should_exit=1
     }
 
@@ -616,28 +622,26 @@ _abbr() {
 
       abbreviation=$1
 
+      (( ABBR_LOADING_USER_ABBREVIATIONS )) && return 0
+
+      (( force && quieter )) && return 0
+
       # Warn if abbreviation would interfere with system command use, e.g. `cp="git cherry-pick"`
       # Apply force to add regardless
-      if ! (( ABBR_LOADING_USER_ABBREVIATIONS )); then
-        if (( force && quiet )); then
-          return 0
-        fi
+      cmd=$('builtin' 'command' -v $abbreviation)
 
-        cmd=$('builtin' 'command' -v $abbreviation)
+      if [[ $cmd && ${cmd:0:6} != 'alias ' ]]; then
+        if (( force )); then
+          verb_phrase="will now expand"
+          (( dry_run )) && verb_phrase="would now expand"
 
-        if [[ $cmd && ${cmd:0:6} != 'alias ' ]]; then
-          if (( force )); then
-            verb_phrase="will now expand"
-            (( dry_run )) && verb_phrase="would now expand"
+          _abbr:util_log_unless_quieter "\`$abbreviation\` $verb_phrase as an abbreviation"
+        else
+          verb_phrase="Did not"
+          (( dry_run )) && verb_phrase="Would not"
 
-            _abbr:util_log "\`$abbreviation\` $verb_phrase as an abbreviation"
-          else
-            verb_phrase="Did not"
-            (( dry_run )) && verb_phrase="Would not"
-
-            _abbr:util_warn "$verb_phrase add the abbreviation \`$abbreviation\` because a command with the same name exists"
-            return 1
-          fi
+          _abbr:util_warn "$verb_phrase add the abbreviation \`$abbreviation\` because a command with the same name exists"
+          return 1
         fi
       fi
     }
@@ -712,10 +716,16 @@ _abbr() {
       _abbr:util_print $result
     }
 
-    _abbr:util_log() {
+    _abbr:util_log_unless_quiet() {
       _abbr_debugger
 
-      logs+="${logs:+\\n}$1"
+      logs_silent_when_quiet+="${logs_silent_when_quiet:+\\n}$1"
+    }
+
+    _abbr:util_log_unless_quieter() {
+      _abbr_debugger
+
+      logs_silent_when_quieter+="${logs_silent_when_quieter:+\\n}$1"
     }
 
     _abbr:util_print() {
@@ -784,7 +794,7 @@ _abbr() {
     _abbr:util_warn() {
       _abbr_debugger
 
-      logs+="${logs:+\\n}$warn_color$@$reset_color"
+      logs_silent_when_quiet+="${logs_silent_when_quiet:+\\n}$warn_color$@$reset_color"
     }
 
     for opt in "$@"; do
@@ -861,6 +871,12 @@ _abbr() {
           quiet=1
           ((number_opts++))
           ;;
+        "--quieter"|\
+        "-qq")
+          quiet=1
+          quieter=1
+          ((number_opts++))
+          ;;
         "--regular"|\
         "-r")
           _abbr:util_set_once type regular
@@ -917,8 +933,14 @@ _abbr() {
     fi
 
     if ! (( quiet )); then
-      if [[ -n $logs ]]; then
-        output=$logs${output:+\\n$output}
+      if [[ -n $logs_silent_when_quiet ]]; then
+        output=$logs_silent_when_quiet${output:+\\n$output}
+      fi
+    fi
+
+    if ! (( quieter )); then
+      if [[ -n $logs_silent_when_quieter ]]; then
+        output=$logs_silent_when_quieter${output:+\\n$output}
       fi
     fi
 


### PR DESCRIPTION
The cost for calling `builtin command` is not trivial if you have many directories in your PATH, and it becomes a real pain to have to wait for a long time when you define/import a lot of abbreviations.  The abbreviations you have in your shell startup file or `~/.config/zsh/abbreviations` are there because you know you are fine with any conflict they may cause, so there should be a way to quickly add abbreviations bypassing the check.