### PR TITLE
Multi word abbreviations (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,14 @@ zsh-abbr has commands to add, rename, and erase abbreviations; to add abbreviati
   % gco[Enter] # expands and accepts git checkout
   ```
 
-  The ABBREVIATION must be only one word long.
+  The ABBREVIATION may be more than one word long.
+
+  ```shell
+  % abbr "git cp"="git cherry-pick"
+  % git cp[Space] # expands as git cherry-pick
+  % abbr g=git
+  % g[Space]cp[Space] # expands to git cherry-pick
+  ```
 
   As with aliases, to include whitespace, quotation marks, or other special characters like `;`, `|`, or `&` in the EXPANSION, quote the EXPANSION or `\`-escape the characters as necessary.
 

--- a/man/man1/abbr.1
+++ b/man/man1/abbr.1
@@ -54,6 +54,8 @@ Will error rather than overwrite an existing abbreviation.
 
 Will warn if the abbreviation would replace an existing command. To add in spite of the warning, use [\fI\-\-force\fR].
 
+May be multiple words. Quote or escape word delimiters.
+
 .IP \(bu
 \fBclear\-session\fR or \fBc\fR
 

--- a/tests/abbr.ztr
+++ b/tests/abbr.ztr
@@ -264,32 +264,32 @@ abbr erase $test_abbr_abbreviation
 
 abbr import-git-aliases --file ${0:A:h}/test-gitconfig
 
-ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[test-subcommand]} == "git status" ]] \
-		&& [[ ${ABBR_GLOBAL_USER_ABBREVIATIONS[gtest-subcommand]} == "git status" ]]' \
+ztr test '[[ $(abbr expand test-subcommand) == "git status" ]] \
+		&& [[ $(abbr expand gtest-subcommand) == "git status" ]]' \
 	"Can import single-word subcommand Git aliases" \
-	"Dependencies: erase"
+	"Dependencies: erase, expand"
 abbr erase test-subcommand
 abbr erase gtest-subcommand
 
-ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[test-subcommand-multi-word]} == "git checkout main" ]] \
-		&& [[ ${ABBR_GLOBAL_USER_ABBREVIATIONS[gtest-subcommand-multi-word]} == "git checkout main" ]]' \
+ztr test '[[ $(abbr expand test-subcommand-multiword) == "git checkout main" ]] \
+		&& [[ $(abbr expand gtest-subcommand-multiword) == "git checkout main" ]]' \
 	"Can import multi-word subcommand Git aliases" \
-	"Dependencies: erase"
+	"Dependencies: erase, expand"
 abbr erase test-subcommand-multi-word
 abbr erase gtest-subcommand-multi-word
 
-ztr test '(( ! ${+ABBR_REGULAR_USER_ABBREVIATIONS[test-command]} )) \
-		&& (( ! ${+ABBR_GLOBAL_USER_ABBREVIATIONS[gtest-command]} ))' \
+ztr test '(( ! ${+ABBR_REGULAR_USER_ABBREVIATIONS["test-command"]} )) \
+		&& (( ! ${+ABBR_GLOBAL_USER_ABBREVIATIONS["gtest-command"]} ))' \
 	"Cannot import command Git aliases" \
 	"Dependencies: erase"
 
-ztr test '(( ! ${+ABBR_REGULAR_USER_ABBREVIATIONS[test-function]} )) \
-		&& (( ! ${+ABBR_GLOBAL_USER_ABBREVIATIONS[gtest-function]} ))' \
+ztr test '(( ! ${+ABBR_REGULAR_USER_ABBREVIATIONS["test-function"]} )) \
+		&& (( ! ${+ABBR_GLOBAL_USER_ABBREVIATIONS["gtest-function"]} ))' \
 	"Cannot import single-line function Git aliases" \
 	"Dependencies: erase"
 
-ztr test '(( ! ${+ABBR_REGULAR_USER_ABBREVIATIONS[test-function-multiline]} )) \
-		&& (( ! ${+ABBR_GLOBAL_USER_ABBREVIATIONS[gtest-function-multiline]} ))' \
+ztr test '(( ! ${+ABBR_REGULAR_USER_ABBREVIATIONS["test-function-multiline"]} )) \
+		&& (( ! ${+ABBR_GLOBAL_USER_ABBREVIATIONS["gtest-function-multiline"]} ))' \
 	"Cannot import multi-line function Git aliases" \
 	"Dependencies: erase"
 

--- a/tests/abbr.ztr
+++ b/tests/abbr.ztr
@@ -8,6 +8,7 @@ ABBR_USER_ABBREVIATIONS_FILE=${0:A:h}/abbreviations.$RANDOM
 touch $ABBR_USER_ABBREVIATIONS_FILE
 
 test_abbr_abbreviation="zsh_abbr_test"
+test_abbr_abbreviation_2="zsh_abbr_test_2"
 test_abbr_abbreviation_multiword="zsh_abbr_test second_word"
 test_abbr_abbreviation_multiword_2="zsh_abbr_test other_second_word"
 test_abbr_expansion="zsh abbr test"
@@ -32,61 +33,61 @@ ztr test '[[ ${#ABBR_REGULAR_USER_ABBREVIATIONS} == 0 ]]' \
 	"Dependencies: add"
 
 abbr add $test_abbr_abbreviation=$test_abbr_expansion
-ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)test_abbr_abbreviation}]} == ${(qqq)test_abbr_expansion} ]]' \
 	"Can add an abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
 
 abbr add $test_abbr_abbreviation_multiword=$test_abbr_expansion
-ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)test_abbr_abbreviation_multiword}]} == ${(qqq)test_abbr_expansion} ]]' \
 	"Can add a multi-word abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword
 
 abbr add -g $test_abbr_abbreviation=$test_abbr_expansion
-ztr test '[[ ${ABBR_GLOBAL_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)test_abbr_abbreviation}]} == ${(qqq)test_abbr_expansion} ]]' \
 	"Can add a global abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
 
 abbr add -g $test_abbr_abbreviation_multiword=$test_abbr_expansion
-ztr test '[[ ${ABBR_GLOBAL_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)test_abbr_abbreviation_multiword}]} == ${(qqq)test_abbr_expansion} ]]' \
 	"Can add a multi-word global abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword
 
 abbr add -S $test_abbr_abbreviation=$test_abbr_expansion
-ztr test '[[ ${ABBR_REGULAR_SESSION_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)test_abbr_abbreviation}]} == ${(qqq)test_abbr_expansion} ]]' \
 	"Can add a regular session abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
 
 abbr add -S $test_abbr_abbreviation_multiword=$test_abbr_expansion
-ztr test '[[ ${ABBR_REGULAR_SESSION_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)test_abbr_abbreviation_multiword}]} == ${(qqq)test_abbr_expansion} ]]' \
 	"Can add a multi-word regular session abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword
 
 abbr add -S -g $test_abbr_abbreviation=$test_abbr_expansion
-ztr test '[[ ${ABBR_GLOBAL_SESSION_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_GLOBAL_SESSION_ABBREVIATIONS[${(qqq)test_abbr_abbreviation}]} == ${(qqq)test_abbr_expansion} ]]' \
 	"Can add a global session abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
 
 abbr add -S -g $test_abbr_abbreviation_multiword=$test_abbr_expansion
-ztr test '[[ ${ABBR_GLOBAL_SESSION_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_GLOBAL_SESSION_ABBREVIATIONS[${(qqq)test_abbr_abbreviation_multiword}]} == ${(qqq)test_abbr_expansion} ]]' \
 	"Can add a multi-word global session abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword
 
 abbr $test_abbr_abbreviation=$test_abbr_expansion
-ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)test_abbr_abbreviation}]} == ${(qqq)test_abbr_expansion} ]]' \
 	"Can add an abbreviation without the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
 
 abbr $test_abbr_abbreviation_multiword=$test_abbr_expansion
-ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)test_abbr_abbreviation_multiword}]} == ${(qqq)test_abbr_expansion} ]]' \
 	"Can add a multi-word abbreviation without the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword
@@ -96,7 +97,7 @@ abbr clear-session
 ztr test '[[ ${#ABBR_REGULAR_SESSION_ABBREVIATIONS} == 0 ]]' \
 	"Can clear session abbreviations"
 
-abbr $test_abbr_abbreviation=$test_abbr_expansion
+abbr add $test_abbr_abbreviation=$test_abbr_expansion
 ztr test '[[ $(abbr expand $test_abbr_abbreviation) == $test_abbr_expansion ]]' \
 	"Can expand an abbreviation in a script" \
 	"Dependencies: erase"
@@ -109,33 +110,33 @@ ztr test '[[ $(abbr expand $test_abbr_abbreviation_multiword) == $test_abbr_expa
 abbr erase $test_abbr_abbreviation_multiword
 
 abbr $test_abbr_abbreviation=$test_abbr_expansion
-abbr rename $test_abbr_abbreviation ${test_abbr_abbreviation}_new
-ztr test '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} )) \
-		&& [[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${test_abbr_abbreviation}_new]} == $test_abbr_expansion ]]' \
+abbr rename $test_abbr_abbreviation $test_abbr_abbreviation_2
+ztr test '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)test_abbr_abbreviation}]} )) \
+		&& [[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)test_abbr_abbreviation_2]} == ${(qqq)test_abbr_expansion} ]]' \
 	"Can rename a single-word abbreviation to another single word" \
 	"Dependencies: erase"
-abbr erase ${test_abbr_abbreviation}_new
+abbr erase $test_abbr_abbreviation_2
 
 abbr $test_abbr_abbreviation=$test_abbr_expansion
 abbr rename $test_abbr_abbreviation $test_abbr_abbreviation_multiword
-ztr test '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} )) \
-		&& [[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+ztr test '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)test_abbr_abbreviation}]} )) \
+		&& [[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)test_abbr_abbreviation_multiword}]} == ${(qqq)test_abbr_expansion} ]]' \
 	"Can rename an single-word abbreviation to multiple words" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword
 
 abbr $test_abbr_abbreviation_multiword=$test_abbr_expansion
 abbr rename $test_abbr_abbreviation_multiword $test_abbr_abbreviation_multiword_2
-ztr test '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} )) \
-		&& [[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword_2]} == $test_abbr_expansion ]]' \
+ztr test '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)test_abbr_abbreviation_multiword}]} )) \
+		&& [[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)test_abbr_abbreviation_multiword_2}]} == ${(qqq)test_abbr_expansion} ]]' \
 	"Can rename an multi-word abbreviation to different words" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword_2
 
 abbr $test_abbr_abbreviation_multiword=$test_abbr_expansion
 abbr rename $test_abbr_abbreviation_multiword $test_abbr_abbreviation
-ztr test '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} )) \
-		&& [[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
+ztr test '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)test_abbr_abbreviation_multiword}]} )) \
+		&& [[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)test_abbr_abbreviation}]} == ${(qqq)test_abbr_expansion} ]]' \
 	"Can rename an multi-word abbreviation to a single word" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
@@ -143,7 +144,7 @@ abbr erase $test_abbr_abbreviation
 abbreviation=a
 expansion="b'c'd"
 abbr $abbreviation=$expansion
-ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]} == ${(qqq)expansion} ]]' \
 	"Double-quoted single quotes in the expansion are preserved" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -151,7 +152,7 @@ abbr erase $abbreviation
 abbreviation=a
 expansion='b"c"d'
 abbr $abbreviation=$expansion
-ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]} == ${(qqq)expansion} ]]' \
 	"Single-quoted double quotes in the expansion are preserved" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -159,7 +160,7 @@ abbr erase $abbreviation
 abbreviation=a
 expansion='b'cd
 abbr $abbreviation=$expansion
-ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]} == ${(qqq)expansion} ]]' \
 	"Bare single quotes at the start of the expansion are swallowed" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -167,7 +168,7 @@ abbr erase $abbreviation
 abbreviation=a
 expansion=b'c'd
 abbr $abbreviation=$expansion
-ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]} == ${(qqq)expansion} ]]' \
 	"Bare single quotes in the middle of the expansion are swallowed" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -175,7 +176,7 @@ abbr erase $abbreviation
 abbreviation=a
 expansion="b"cd
 abbr $abbreviation=$expansion
-ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]} == ${(qqq)expansion} ]]' \
 	"Bare double quotes at the start of the expansion are swallowed" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -183,7 +184,7 @@ abbr erase $abbreviation
 abbreviation=a
 expansion=b"c"d
 abbr $abbreviation=$expansion
-ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]} == ${(qqq)expansion} ]]' \
 	"Bare double quotes in the middle of the expansion are swallowed" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -192,7 +193,7 @@ abbreviation=zsh_abbr_test_alias
 expansion=abc
 alias $abbreviation=$expansion
 abbr import-aliases
-ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]} == ${(qqq)expansion} ]]' \
 	"Can import aliases" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -205,7 +206,7 @@ abbreviation=zsh_abbr_test_alias
 expansion="a b"
 alias $abbreviation=$expansion
 abbr import-aliases
-ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]} == ${(qqq)expansion} ]]' \
 	"Can import a multi-word alias" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -218,7 +219,7 @@ abbreviation=zsh_abbr_test_alias
 expansion="a \"b\""
 alias $abbreviation=$expansion
 abbr import-aliases
-ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]} == ${(qqq)expansion} ]]' \
 	"Can import a double-quoted alias with escaped double quotation marks" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -231,7 +232,7 @@ abbreviation=zsh_abbr_test_alias
 expansion='a "b"'
 alias $abbreviation=$expansion
 abbr import-aliases
-ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]} == ${(qqq)expansion} ]]' \
 	"Can import a single-quoted alias with double quotation marks" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -244,7 +245,7 @@ abbreviation=zsh_abbr_test_alias
 expansion="a 'b'"
 alias $abbreviation=$expansion
 abbr import-aliases
-ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]} == ${(qqq)expansion} ]]' \
 	"Can import a double-quoted alias with single quotation marks" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -256,7 +257,7 @@ ztr test '[[ -z $(abbr expand $test_abbr_abbreviation) ]]' \
 	"Can delete a user abbreviation from outside abbr without unexpected retention"
 
 echo "abbr add $test_abbr_abbreviation='$test_abbr_expansion'" > $ABBR_USER_ABBREVIATIONS_FILE
-ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)test_abbr_abbreviation}]} == ${(qqq)test_abbr_expansion} ]]' \
 	"Can add a user abbreviation from outside abbr without data loss" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation

--- a/tests/abbr.ztr
+++ b/tests/abbr.ztr
@@ -112,7 +112,7 @@ abbr erase $test_abbr_abbreviation_multiword
 abbr $test_abbr_abbreviation=$test_abbr_expansion
 abbr rename $test_abbr_abbreviation $test_abbr_abbreviation_2
 ztr test '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)test_abbr_abbreviation}]} )) \
-		&& [[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)test_abbr_abbreviation_2]} == ${(qqq)test_abbr_expansion} ]]' \
+		&& [[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)test_abbr_abbreviation_2}]} == ${(qqq)test_abbr_expansion} ]]' \
 	"Can rename a single-word abbreviation to another single word" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_2

--- a/tests/abbr.ztr
+++ b/tests/abbr.ztr
@@ -27,7 +27,7 @@ ztr test '[[ ${#ABBR_REGULAR_USER_ABBREVIATIONS} == 0 ]]' \
 
 abbr add $test_abbr_abbreviation_multiword=$test_abbr_expansion
 abbr erase $test_abbr_abbreviation_multiword
-ztr skip '[[ ${#ABBR_REGULAR_USER_ABBREVIATIONS} == 0 ]]' \
+ztr test '[[ ${#ABBR_REGULAR_USER_ABBREVIATIONS} == 0 ]]' \
 	"Can erase a multi-word abbreviation" \
 	"Dependencies: add"
 
@@ -38,7 +38,7 @@ ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $
 abbr erase $test_abbr_abbreviation
 
 abbr add $test_abbr_abbreviation_multiword=$test_abbr_expansion
-ztr skip '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
 	"Can add a multi-word abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword
@@ -50,7 +50,7 @@ ztr test '[[ ${(Q)ABBR_GLOBAL_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $t
 abbr erase $test_abbr_abbreviation
 
 abbr add -g $test_abbr_abbreviation_multiword=$test_abbr_expansion
-ztr skip '[[ ${(Q)ABBR_GLOBAL_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${(Q)ABBR_GLOBAL_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
 	"Can add a multi-word global abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword
@@ -62,7 +62,7 @@ ztr test '[[ ${(Q)ABBR_REGULAR_SESSION_ABBREVIATIONS[$test_abbr_abbreviation]} =
 abbr erase $test_abbr_abbreviation
 
 abbr add -S $test_abbr_abbreviation_multiword=$test_abbr_expansion
-ztr skip '[[ ${(Q)ABBR_REGULAR_SESSION_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${(Q)ABBR_REGULAR_SESSION_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
 	"Can add a multi-word regular session abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword
@@ -74,7 +74,7 @@ ztr test '[[ ${(Q)ABBR_GLOBAL_SESSION_ABBREVIATIONS[$test_abbr_abbreviation]} ==
 abbr erase $test_abbr_abbreviation
 
 abbr add -S -g $test_abbr_abbreviation_multiword=$test_abbr_expansion
-ztr skip '[[ ${(Q)ABBR_GLOBAL_SESSION_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${(Q)ABBR_GLOBAL_SESSION_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
 	"Can add a multi-word global session abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword
@@ -86,7 +86,7 @@ ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $
 abbr erase $test_abbr_abbreviation
 
 abbr $test_abbr_abbreviation_multiword=$test_abbr_expansion
-ztr skip '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
 	"Can add a multi-word abbreviation without the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword
@@ -103,7 +103,7 @@ ztr test '[[ $(abbr expand $test_abbr_abbreviation) == $test_abbr_expansion ]]' 
 abbr erase $test_abbr_abbreviation
 
 abbr $test_abbr_abbreviation_multiword=$test_abbr_expansion
-ztr skip '[[ $(abbr expand $test_abbr_abbreviation_multiword) == $test_abbr_expansion ]]' \
+ztr test '[[ $(abbr expand $test_abbr_abbreviation_multiword) == $test_abbr_expansion ]]' \
 	"Can expand a multi-word abbreviation in a script" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword
@@ -118,7 +118,7 @@ abbr erase ${test_abbr_abbreviation}_new
 
 abbr $test_abbr_abbreviation=$test_abbr_expansion
 abbr rename $test_abbr_abbreviation $test_abbr_abbreviation_multiword
-ztr skip '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} )) \
+ztr test '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} )) \
 		&& [[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
 	"Can rename an single-word abbreviation to multiple words" \
 	"Dependencies: erase"
@@ -126,7 +126,7 @@ abbr erase $test_abbr_abbreviation_multiword
 
 abbr $test_abbr_abbreviation_multiword=$test_abbr_expansion
 abbr rename $test_abbr_abbreviation_multiword $test_abbr_abbreviation_multiword_2
-ztr skip '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} )) \
+ztr test '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} )) \
 		&& [[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword_2]} == $test_abbr_expansion ]]' \
 	"Can rename an multi-word abbreviation to different words" \
 	"Dependencies: erase"
@@ -134,7 +134,7 @@ abbr erase $test_abbr_abbreviation_multiword_2
 
 abbr $test_abbr_abbreviation_multiword=$test_abbr_expansion
 abbr rename $test_abbr_abbreviation_multiword $test_abbr_abbreviation
-ztr skip '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} )) \
+ztr test '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} )) \
 		&& [[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
 	"Can rename an multi-word abbreviation to a single word" \
 	"Dependencies: erase"

--- a/tests/abbr.ztr
+++ b/tests/abbr.ztr
@@ -1,4 +1,3 @@
-
 # Tests require ztr
 # https://github.com/olets/zsh-test-runner
 # Run the suite by sourcing it or by passing it to `zsh`
@@ -9,6 +8,8 @@ ABBR_USER_ABBREVIATIONS_FILE=${0:A:h}/abbreviations.$RANDOM
 touch $ABBR_USER_ABBREVIATIONS_FILE
 
 test_abbr_abbreviation="zsh_abbr_test"
+test_abbr_abbreviation_multiword="zsh_abbr_test second_word"
+test_abbr_abbreviation_multiword_2="zsh_abbr_test other_second_word"
 test_abbr_expansion="zsh abbr test"
 
 source ${0:A:h}/../zsh-abbr.zsh
@@ -24,11 +25,23 @@ ztr test '[[ ${#ABBR_REGULAR_USER_ABBREVIATIONS} == 0 ]]' \
 	"Can erase an abbreviation" \
 	"Dependencies: add"
 
+abbr add $test_abbr_abbreviation_multiword=$test_abbr_expansion
+abbr erase $test_abbr_abbreviation_multiword
+ztr skip '[[ ${#ABBR_REGULAR_USER_ABBREVIATIONS} == 0 ]]' \
+	"Can erase a multi-word abbreviation" \
+	"Dependencies: add"
+
 abbr add $test_abbr_abbreviation=$test_abbr_expansion
 ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
 	"Can add an abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
+
+abbr add $test_abbr_abbreviation_multiword=$test_abbr_expansion
+ztr skip '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+	"Can add a multi-word abbreviation with the add flag" \
+	"Dependencies: erase"
+abbr erase $test_abbr_abbreviation_multiword
 
 abbr add -g $test_abbr_abbreviation=$test_abbr_expansion
 ztr test '[[ ${(Q)ABBR_GLOBAL_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
@@ -36,11 +49,23 @@ ztr test '[[ ${(Q)ABBR_GLOBAL_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $t
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
 
+abbr add -g $test_abbr_abbreviation_multiword=$test_abbr_expansion
+ztr skip '[[ ${(Q)ABBR_GLOBAL_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+	"Can add a multi-word global abbreviation with the add flag" \
+	"Dependencies: erase"
+abbr erase $test_abbr_abbreviation_multiword
+
 abbr add -S $test_abbr_abbreviation=$test_abbr_expansion
 ztr test '[[ ${(Q)ABBR_REGULAR_SESSION_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
 	"Can add a regular session abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
+
+abbr add -S $test_abbr_abbreviation_multiword=$test_abbr_expansion
+ztr skip '[[ ${(Q)ABBR_REGULAR_SESSION_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+	"Can add a multi-word regular session abbreviation with the add flag" \
+	"Dependencies: erase"
+abbr erase $test_abbr_abbreviation_multiword
 
 abbr add -S -g $test_abbr_abbreviation=$test_abbr_expansion
 ztr test '[[ ${(Q)ABBR_GLOBAL_SESSION_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
@@ -48,11 +73,23 @@ ztr test '[[ ${(Q)ABBR_GLOBAL_SESSION_ABBREVIATIONS[$test_abbr_abbreviation]} ==
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
 
+abbr add -S -g $test_abbr_abbreviation_multiword=$test_abbr_expansion
+ztr skip '[[ ${(Q)ABBR_GLOBAL_SESSION_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+	"Can add a multi-word global session abbreviation with the add flag" \
+	"Dependencies: erase"
+abbr erase $test_abbr_abbreviation_multiword
+
 abbr $test_abbr_abbreviation=$test_abbr_expansion
 ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
 	"Can add an abbreviation without the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
+
+abbr $test_abbr_abbreviation_multiword=$test_abbr_expansion
+ztr skip '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+	"Can add a multi-word abbreviation without the add flag" \
+	"Dependencies: erase"
+abbr erase $test_abbr_abbreviation_multiword
 
 abbr -S $test_abbr_abbreviation=$test_abbr_expansion
 abbr clear-session
@@ -65,13 +102,43 @@ ztr test '[[ $(abbr expand $test_abbr_abbreviation) == $test_abbr_expansion ]]' 
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
 
+abbr $test_abbr_abbreviation_multiword=$test_abbr_expansion
+ztr skip '[[ $(abbr expand $test_abbr_abbreviation_multiword) == $test_abbr_expansion ]]' \
+	"Can expand a multi-word abbreviation in a script" \
+	"Dependencies: erase"
+abbr erase $test_abbr_abbreviation_multiword
+
 abbr $test_abbr_abbreviation=$test_abbr_expansion
 abbr rename $test_abbr_abbreviation ${test_abbr_abbreviation}_new
 ztr test '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} )) \
 		&& [[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[${test_abbr_abbreviation}_new]} == $test_abbr_expansion ]]' \
-	"Can rename an abbreviation" \
+	"Can rename a single-word abbreviation to another single word" \
 	"Dependencies: erase"
 abbr erase ${test_abbr_abbreviation}_new
+
+abbr $test_abbr_abbreviation=$test_abbr_expansion
+abbr rename $test_abbr_abbreviation $test_abbr_abbreviation_multiword
+ztr skip '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} )) \
+		&& [[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+	"Can rename an single-word abbreviation to multiple words" \
+	"Dependencies: erase"
+abbr erase $test_abbr_abbreviation_multiword
+
+abbr $test_abbr_abbreviation_multiword=$test_abbr_expansion
+abbr rename $test_abbr_abbreviation_multiword $test_abbr_abbreviation_multiword_2
+ztr skip '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} )) \
+		&& [[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword_2]} == $test_abbr_expansion ]]' \
+	"Can rename an multi-word abbreviation to different words" \
+	"Dependencies: erase"
+abbr erase $test_abbr_abbreviation_multiword_2
+
+abbr $test_abbr_abbreviation_multiword=$test_abbr_expansion
+abbr rename $test_abbr_abbreviation_multiword $test_abbr_abbreviation
+ztr skip '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} )) \
+		&& [[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
+	"Can rename an multi-word abbreviation to a single word" \
+	"Dependencies: erase"
+abbr erase $test_abbr_abbreviation
 
 abbreviation=a
 expansion="b'c'd"
@@ -203,12 +270,12 @@ ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[test-subcommand]} == "git stat
 abbr erase test-subcommand
 abbr erase gtest-subcommand
 
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[test-subcommand-multiword]} == "git checkout main" ]] \
-		&& [[ ${(Q)ABBR_GLOBAL_USER_ABBREVIATIONS[gtest-subcommand-multiword]} == "git checkout main" ]]' \
+ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[test-subcommand-multi-word]} == "git checkout main" ]] \
+		&& [[ ${(Q)ABBR_GLOBAL_USER_ABBREVIATIONS[gtest-subcommand-multi-word]} == "git checkout main" ]]' \
 	"Can import multi-word subcommand Git aliases" \
 	"Dependencies: erase"
-abbr erase test-subcommand-multiword
-abbr erase gtest-subcommand-multiword
+abbr erase test-subcommand-multi-word
+abbr erase gtest-subcommand-multi-word
 
 ztr test '(( ! ${+ABBR_REGULAR_USER_ABBREVIATIONS[test-command]} )) \
 		&& (( ! ${+ABBR_GLOBAL_USER_ABBREVIATIONS[gtest-command]} ))' \

--- a/tests/abbr.ztr
+++ b/tests/abbr.ztr
@@ -103,6 +103,24 @@ ztr test '[[ $(abbr expand $test_abbr_abbreviation) == $test_abbr_expansion ]]' 
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
 
+abbr add -g $test_abbr_abbreviation=$test_abbr_expansion
+ztr test '[[ $(abbr expand $test_abbr_abbreviation) == $test_abbr_expansion ]]' \
+	"Can expand a global abbreviation in a script" \
+	"Dependencies: erase"
+abbr erase $test_abbr_abbreviation
+
+abbr add -S $test_abbr_abbreviation=$test_abbr_expansion
+ztr test '[[ $(abbr expand $test_abbr_abbreviation) == $test_abbr_expansion ]]' \
+	"Can expand a session abbreviation in a script" \
+	"Dependencies: erase"
+abbr erase $test_abbr_abbreviation
+
+abbr add -S -g $test_abbr_abbreviation=$test_abbr_expansion
+ztr test '[[ $(abbr expand $test_abbr_abbreviation) == $test_abbr_expansion ]]' \
+	"Can expand a global session abbreviation in a script" \
+	"Dependencies: erase"
+abbr erase $test_abbr_abbreviation
+
 abbr $test_abbr_abbreviation_multiword=$test_abbr_expansion
 ztr test '[[ $(abbr expand $test_abbr_abbreviation_multiword) == $test_abbr_expansion ]]' \
 	"Can expand a multi-word abbreviation in a script" \

--- a/tests/abbr.ztr
+++ b/tests/abbr.ztr
@@ -32,61 +32,61 @@ ztr test '[[ ${#ABBR_REGULAR_USER_ABBREVIATIONS} == 0 ]]' \
 	"Dependencies: add"
 
 abbr add $test_abbr_abbreviation=$test_abbr_expansion
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
 	"Can add an abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
 
 abbr add $test_abbr_abbreviation_multiword=$test_abbr_expansion
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
 	"Can add a multi-word abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword
 
 abbr add -g $test_abbr_abbreviation=$test_abbr_expansion
-ztr test '[[ ${(Q)ABBR_GLOBAL_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_GLOBAL_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
 	"Can add a global abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
 
 abbr add -g $test_abbr_abbreviation_multiword=$test_abbr_expansion
-ztr test '[[ ${(Q)ABBR_GLOBAL_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_GLOBAL_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
 	"Can add a multi-word global abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword
 
 abbr add -S $test_abbr_abbreviation=$test_abbr_expansion
-ztr test '[[ ${(Q)ABBR_REGULAR_SESSION_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_SESSION_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
 	"Can add a regular session abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
 
 abbr add -S $test_abbr_abbreviation_multiword=$test_abbr_expansion
-ztr test '[[ ${(Q)ABBR_REGULAR_SESSION_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_SESSION_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
 	"Can add a multi-word regular session abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword
 
 abbr add -S -g $test_abbr_abbreviation=$test_abbr_expansion
-ztr test '[[ ${(Q)ABBR_GLOBAL_SESSION_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_GLOBAL_SESSION_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
 	"Can add a global session abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
 
 abbr add -S -g $test_abbr_abbreviation_multiword=$test_abbr_expansion
-ztr test '[[ ${(Q)ABBR_GLOBAL_SESSION_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_GLOBAL_SESSION_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
 	"Can add a multi-word global session abbreviation with the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword
 
 abbr $test_abbr_abbreviation=$test_abbr_expansion
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
 	"Can add an abbreviation without the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
 
 abbr $test_abbr_abbreviation_multiword=$test_abbr_expansion
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
 	"Can add a multi-word abbreviation without the add flag" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword
@@ -111,7 +111,7 @@ abbr erase $test_abbr_abbreviation_multiword
 abbr $test_abbr_abbreviation=$test_abbr_expansion
 abbr rename $test_abbr_abbreviation ${test_abbr_abbreviation}_new
 ztr test '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} )) \
-		&& [[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[${test_abbr_abbreviation}_new]} == $test_abbr_expansion ]]' \
+		&& [[ ${ABBR_REGULAR_USER_ABBREVIATIONS[${test_abbr_abbreviation}_new]} == $test_abbr_expansion ]]' \
 	"Can rename a single-word abbreviation to another single word" \
 	"Dependencies: erase"
 abbr erase ${test_abbr_abbreviation}_new
@@ -119,7 +119,7 @@ abbr erase ${test_abbr_abbreviation}_new
 abbr $test_abbr_abbreviation=$test_abbr_expansion
 abbr rename $test_abbr_abbreviation $test_abbr_abbreviation_multiword
 ztr test '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} )) \
-		&& [[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
+		&& [[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} == $test_abbr_expansion ]]' \
 	"Can rename an single-word abbreviation to multiple words" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword
@@ -127,7 +127,7 @@ abbr erase $test_abbr_abbreviation_multiword
 abbr $test_abbr_abbreviation_multiword=$test_abbr_expansion
 abbr rename $test_abbr_abbreviation_multiword $test_abbr_abbreviation_multiword_2
 ztr test '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} )) \
-		&& [[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword_2]} == $test_abbr_expansion ]]' \
+		&& [[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword_2]} == $test_abbr_expansion ]]' \
 	"Can rename an multi-word abbreviation to different words" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation_multiword_2
@@ -135,7 +135,7 @@ abbr erase $test_abbr_abbreviation_multiword_2
 abbr $test_abbr_abbreviation_multiword=$test_abbr_expansion
 abbr rename $test_abbr_abbreviation_multiword $test_abbr_abbreviation
 ztr test '! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation_multiword]} )) \
-		&& [[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
+		&& [[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
 	"Can rename an multi-word abbreviation to a single word" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
@@ -143,7 +143,7 @@ abbr erase $test_abbr_abbreviation
 abbreviation=a
 expansion="b'c'd"
 abbr $abbreviation=$expansion
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
 	"Double-quoted single quotes in the expansion are preserved" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -151,7 +151,7 @@ abbr erase $abbreviation
 abbreviation=a
 expansion='b"c"d'
 abbr $abbreviation=$expansion
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
 	"Single-quoted double quotes in the expansion are preserved" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -159,7 +159,7 @@ abbr erase $abbreviation
 abbreviation=a
 expansion='b'cd
 abbr $abbreviation=$expansion
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
 	"Bare single quotes at the start of the expansion are swallowed" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -167,7 +167,7 @@ abbr erase $abbreviation
 abbreviation=a
 expansion=b'c'd
 abbr $abbreviation=$expansion
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
 	"Bare single quotes in the middle of the expansion are swallowed" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -175,7 +175,7 @@ abbr erase $abbreviation
 abbreviation=a
 expansion="b"cd
 abbr $abbreviation=$expansion
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
 	"Bare double quotes at the start of the expansion are swallowed" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -183,7 +183,7 @@ abbr erase $abbreviation
 abbreviation=a
 expansion=b"c"d
 abbr $abbreviation=$expansion
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
 	"Bare double quotes in the middle of the expansion are swallowed" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -192,7 +192,7 @@ abbreviation=zsh_abbr_test_alias
 expansion=abc
 alias $abbreviation=$expansion
 abbr import-aliases
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
 	"Can import aliases" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -205,7 +205,7 @@ abbreviation=zsh_abbr_test_alias
 expansion="a b"
 alias $abbreviation=$expansion
 abbr import-aliases
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
 	"Can import a multi-word alias" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -218,7 +218,7 @@ abbreviation=zsh_abbr_test_alias
 expansion="a \"b\""
 alias $abbreviation=$expansion
 abbr import-aliases
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
 	"Can import a double-quoted alias with escaped double quotation marks" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -231,7 +231,7 @@ abbreviation=zsh_abbr_test_alias
 expansion='a "b"'
 alias $abbreviation=$expansion
 abbr import-aliases
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
 	"Can import a single-quoted alias with double quotation marks" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -244,7 +244,7 @@ abbreviation=zsh_abbr_test_alias
 expansion="a 'b'"
 alias $abbreviation=$expansion
 abbr import-aliases
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} == $expansion ]]' \
 	"Can import a double-quoted alias with single quotation marks" \
 	"Dependencies: erase"
 abbr erase $abbreviation
@@ -256,22 +256,22 @@ ztr test '[[ -z $(abbr expand $test_abbr_abbreviation) ]]' \
 	"Can delete a user abbreviation from outside abbr without unexpected retention"
 
 echo "abbr add $test_abbr_abbreviation='$test_abbr_expansion'" > $ABBR_USER_ABBREVIATIONS_FILE
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[$test_abbr_abbreviation]} == $test_abbr_expansion ]]' \
 	"Can add a user abbreviation from outside abbr without data loss" \
 	"Dependencies: erase"
 abbr erase $test_abbr_abbreviation
 
 abbr import-git-aliases --file ${0:A:h}/test-gitconfig
 
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[test-subcommand]} == "git status" ]] \
-		&& [[ ${(Q)ABBR_GLOBAL_USER_ABBREVIATIONS[gtest-subcommand]} == "git status" ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[test-subcommand]} == "git status" ]] \
+		&& [[ ${ABBR_GLOBAL_USER_ABBREVIATIONS[gtest-subcommand]} == "git status" ]]' \
 	"Can import single-word subcommand Git aliases" \
 	"Dependencies: erase"
 abbr erase test-subcommand
 abbr erase gtest-subcommand
 
-ztr test '[[ ${(Q)ABBR_REGULAR_USER_ABBREVIATIONS[test-subcommand-multi-word]} == "git checkout main" ]] \
-		&& [[ ${(Q)ABBR_GLOBAL_USER_ABBREVIATIONS[gtest-subcommand-multi-word]} == "git checkout main" ]]' \
+ztr test '[[ ${ABBR_REGULAR_USER_ABBREVIATIONS[test-subcommand-multi-word]} == "git checkout main" ]] \
+		&& [[ ${ABBR_GLOBAL_USER_ABBREVIATIONS[gtest-subcommand-multi-word]} == "git checkout main" ]]' \
 	"Can import multi-word subcommand Git aliases" \
 	"Dependencies: erase"
 abbr erase test-subcommand-multi-word

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -94,7 +94,7 @@ _abbr() {
         expansion=${(q)expansion}
       fi
 
-      if ! [[ $abbreviation && $expansion && $abbreviation != $1 ]]; then
+      if [[ -z $abbreviation || -z $expansion || $abbreviation == $1 ]]; then
         _abbr:util_error "abbr add: Requires abbreviation and expansion"
         return
       fi

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -1001,7 +1001,7 @@ _abbr_no_color() {
 _abbr_cmd_expansion() {
   emulate -LR zsh
 
-  # cannout support debug message
+  # cannot support debug message
 
   local abbreviation
   local expansion
@@ -1043,7 +1043,7 @@ _abbr_debugger() {
 _abbr_global_expansion() {
   emulate -LR zsh
 
-  # cannout support debug message
+  # cannot support debug message
 
   local abbreviation
   local expansion
@@ -1139,7 +1139,7 @@ _abbr_job_push() {
     }
 
     function _abbr_job_push:next_job_name() {
-      # cannout support debug message
+      # cannot support debug message
 
       'command' 'ls' -t ${ABBR_TMPDIR}jobs | tail -1
     }
@@ -1184,7 +1184,7 @@ _abbr_job_push() {
 _abbr_job_name() {
   emulate -LR zsh
 
-  # cannout support debug message
+  # cannot support debug message
 
   'builtin' 'echo' "$(date +%s).$RANDOM"
 }

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -471,11 +471,11 @@ _abbr() {
         if [[ $type == 'global' ]]; then
           typed_scope=$(_abbr:util_set_to_typed_scope ABBR_GLOBAL_SESSION_ABBREVIATIONS)
 
-          if ! (( ${+ABBR_GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]} )); then
+          if ! (( ${+ABBR_GLOBAL_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
             _abbr:util_check_command $abbreviation || return
 
             if ! (( dry_run )); then
-              ABBR_GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]=$expansion
+              ABBR_GLOBAL_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]=$expansion
             fi
 
             success=1
@@ -483,11 +483,11 @@ _abbr() {
         else
           typed_scope=$(_abbr:util_set_to_typed_scope ABBR_REGULAR_SESSION_ABBREVIATIONS)
 
-          if ! (( ${+ABBR_REGULAR_SESSION_ABBREVIATIONS[$abbreviation]} )); then
+          if ! (( ${+ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
             _abbr:util_check_command $abbreviation || return
 
             if ! (( dry_run )); then
-              ABBR_REGULAR_SESSION_ABBREVIATIONS[$abbreviation]=$expansion
+              ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]=$expansion
             fi
 
             success=1
@@ -501,11 +501,11 @@ _abbr() {
             source ${ABBR_TMPDIR}global-user-abbreviations
           fi
 
-          if ! (( ${+ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]} )); then
+          if ! (( ${+ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
             _abbr:util_check_command $abbreviation || return
 
             if ! (( dry_run )); then
-              ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]=$expansion
+              ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)abbreviation}]=$expansion
               _abbr:util_sync_user
             fi
 
@@ -518,12 +518,12 @@ _abbr() {
             source ${ABBR_TMPDIR}regular-user-abbreviations
           fi
 
-          if ! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} )); then
+          if ! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
             _abbr:util_check_command $abbreviation || return
             typed_scope=$(_abbr:util_set_to_typed_scope ABBR_REGULAR_USER_ABBREVIATIONS)
 
             if ! (( dry_run )); then
-              ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]=$expansion
+              ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]=$expansion
               _abbr:util_sync_user
             fi
 
@@ -1007,12 +1007,13 @@ _abbr_cmd_expansion() {
   local expansion
 
   abbreviation=$1
-  expansion=${ABBR_REGULAR_SESSION_ABBREVIATIONS[$abbreviation]}
+  
+  expansion=${ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]}
 
   if [[ ! $expansion ]]; then
     _abbr_create_files
     source ${ABBR_TMPDIR}regular-user-abbreviations
-    expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]}
+    expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]}
   fi
 
   'builtin' 'echo' - $expansion

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -131,14 +131,14 @@ _abbr() {
 
       if [[ $scope != 'user' ]]; then
         if [[ $type != 'regular' ]]; then
-          if (( ${+ABBR_GLOBAL_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
+          if (( ${+ABBR_GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]} )); then
             (( ABBR_DEBUG )) && 'builtin' 'echo' "  Found a global session abbreviation"
             abbreviations_sets+=( ABBR_GLOBAL_SESSION_ABBREVIATIONS )
           fi
         fi
 
         if [[ $type != 'global' ]]; then
-          if (( ${+ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
+          if (( ${+ABBR_REGULAR_SESSION_ABBREVIATIONS[$abbreviation]} )); then
             (( ABBR_DEBUG )) && 'builtin' 'echo' "  Found a regular session abbreviation"
             abbreviations_sets+=( ABBR_REGULAR_SESSION_ABBREVIATIONS )
           fi
@@ -151,7 +151,7 @@ _abbr() {
             source ${ABBR_TMPDIR}global-user-abbreviations
           fi
 
-          if (( ${+ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
+          if (( ${+ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]} )); then
             (( ABBR_DEBUG )) && 'builtin' 'echo' "  Found a global user abbreviation"
             abbreviations_sets+=( ABBR_GLOBAL_USER_ABBREVIATIONS )
           fi
@@ -162,7 +162,7 @@ _abbr() {
             source ${ABBR_TMPDIR}regular-user-abbreviations
           fi
 
-          if (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
+          if (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} )); then
             (( ABBR_DEBUG )) && 'builtin' 'echo' "  Found a regular user abbreviation"
             abbreviations_sets+=( ABBR_REGULAR_USER_ABBREVIATIONS )
           fi
@@ -467,11 +467,11 @@ _abbr() {
         if [[ $type == 'global' ]]; then
           typed_scope=$(_abbr:util_set_to_typed_scope ABBR_GLOBAL_SESSION_ABBREVIATIONS)
 
-          if ! (( ${+ABBR_GLOBAL_SESSION_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]} )); then
+          if ! (( ${+ABBR_GLOBAL_SESSION_ABBREVIATIONS[${(Q)abbreviation}]} )); then
             _abbr:util_check_command $abbreviation || return
 
             if ! (( dry_run )); then
-              ABBR_GLOBAL_SESSION_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]=$expansion
+              ABBR_GLOBAL_SESSION_ABBREVIATIONS[${(Q)abbreviation}]=${(Q)expansion}
             fi
 
             success=1
@@ -479,11 +479,11 @@ _abbr() {
         else
           typed_scope=$(_abbr:util_set_to_typed_scope ABBR_REGULAR_SESSION_ABBREVIATIONS)
 
-          if ! (( ${+ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]} )); then
+          if ! (( ${+ABBR_REGULAR_SESSION_ABBREVIATIONS[${(Q)abbreviation}]} )); then
             _abbr:util_check_command $abbreviation || return
 
             if ! (( dry_run )); then
-              ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]=$expansion
+              ABBR_REGULAR_SESSION_ABBREVIATIONS[${(Q)abbreviation}]=${(Q)expansion}
             fi
 
             success=1
@@ -497,11 +497,11 @@ _abbr() {
             source ${ABBR_TMPDIR}global-user-abbreviations
           fi
 
-          if ! (( ${+ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]} )); then
+          if ! (( ${+ABBR_GLOBAL_USER_ABBREVIATIONS[${(Q)abbreviation}]} )); then
             _abbr:util_check_command $abbreviation || return
 
             if ! (( dry_run )); then
-              ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]=$expansion
+              ABBR_GLOBAL_USER_ABBREVIATIONS[${(Q)abbreviation}]=${(Q)expansion}
               _abbr:util_sync_user
             fi
 
@@ -514,12 +514,12 @@ _abbr() {
             source ${ABBR_TMPDIR}regular-user-abbreviations
           fi
 
-          if ! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]} )); then
+          if ! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[${(Q)abbreviation}]} )); then
             _abbr:util_check_command $abbreviation || return
             typed_scope=$(_abbr:util_set_to_typed_scope ABBR_REGULAR_USER_ABBREVIATIONS)
 
             if ! (( dry_run )); then
-              ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]=$expansion
+              ABBR_REGULAR_USER_ABBREVIATIONS[${(Q)abbreviation}]=${(Q)expansion}
               _abbr:util_sync_user
             fi
 
@@ -1004,15 +1004,15 @@ _abbr_cmd_expansion() {
 
   abbreviation=$1
   
-  expansion=${ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]}
+  expansion=${ABBR_REGULAR_SESSION_ABBREVIATIONS[$abbreviation]}
 
   if [[ ! $expansion ]]; then
     _abbr_create_files
     source ${ABBR_TMPDIR}regular-user-abbreviations
-    expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]}
+    expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]}
   fi
 
-  'builtin' 'echo' - ${(Q)expansion}
+  'builtin' 'echo' - $expansion
 }
 
 _abbr_create_files() {

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -755,13 +755,13 @@ _abbr() {
       typeset -p ABBR_GLOBAL_USER_ABBREVIATIONS > ${ABBR_TMPDIR}global-user-abbreviations
       for abbreviation in ${(ikoQ)ABBR_GLOBAL_USER_ABBREVIATIONS}; do
         expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]}
-        'builtin' 'echo' "abbr -g ${(qqq)${(Q)abbreviation}}=${(qqq)${(Q)expansion}}" >> "$user_updated"
+        'builtin' 'echo' "abbr -g ${(qqq)abbreviation}=${(qqq)expansion}" >> "$user_updated"
       done
 
       typeset -p ABBR_REGULAR_USER_ABBREVIATIONS > ${ABBR_TMPDIR}regular-user-abbreviations
       for abbreviation in ${(ikoQ)ABBR_REGULAR_USER_ABBREVIATIONS}; do
         expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]}
-        'builtin' 'echo' "abbr ${(qqq)${(Q)abbreviation}}=${(qqq)${(Q)expansion}}" >> $user_updated
+        'builtin' 'echo' "abbr ${(qqq)abbreviation}=${(qqq)expansion}" >> $user_updated
       done
 
       mv $user_updated $ABBR_USER_ABBREVIATIONS_FILE

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -89,10 +89,6 @@ _abbr() {
       abbreviation=${1%%=*}
       expansion=${1#*=}
 
-      if ! (( ABBR_LOADING_USER_ABBREVIATIONS )); then
-        abbreviation=${(q)abbreviation}
-        expansion=${(q)expansion}
-      fi
 
       if [[ -z $abbreviation || -z $expansion || $abbreviation == $1 ]]; then
         _abbr:util_error "abbr add: Requires abbreviation and expansion"

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -1285,27 +1285,32 @@ _abbr_widget_expand() {
   emulate -LR zsh
 
   local expansion
-  local word
-  local words
-  local -i word_count
+  local abbreviation
+  local preceding_lbuffer
+  local -a words
 
-  words=(${(z)LBUFFER})
-  word=$words[-1]
-  word_count=${#words}
-
-  if [[ $word_count == 1 ]]; then
-    expansion=$(_abbr_cmd_expansion $word)
-  fi
-
-  if [[ ! $expansion ]]; then
-    expansion=$(_abbr_global_expansion $word)
-  fi
+  expansion=$(_abbr_cmd_expansion $LBUFFER)
 
   if [[ -n $expansion ]]; then
-    local preceding_lbuffer
-    preceding_lbuffer=${LBUFFER%%$word}
-    LBUFFER=$preceding_lbuffer${(Q)expansion}
+    LBUFFER=${(Q)expansion}
+    return
   fi
+
+  words=(${(z)LBUFFER})
+  
+  while (( i < ${#words} )); do
+    abbreviation=${words:$i}
+    expansion=$(_abbr_global_expansion $abbreviation)
+
+    if [[ -n $expansion ]]; then
+      preceding_lbuffer=${LBUFFER%%$abbreviation}
+
+      LBUFFER=$preceding_lbuffer${(Q)expansion}
+      break
+    fi
+
+    (( i++ ))
+  done
 }
 
 _abbr_widget_expand_and_accept() {

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -131,14 +131,14 @@ _abbr() {
 
       if [[ $scope != 'user' ]]; then
         if [[ $type != 'regular' ]]; then
-          if (( ${+ABBR_GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]} )); then
+          if (( ${+ABBR_GLOBAL_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
             (( ABBR_DEBUG )) && 'builtin' 'echo' "  Found a global session abbreviation"
             abbreviations_sets+=( ABBR_GLOBAL_SESSION_ABBREVIATIONS )
           fi
         fi
 
         if [[ $type != 'global' ]]; then
-          if (( ${+ABBR_REGULAR_SESSION_ABBREVIATIONS[$abbreviation]} )); then
+          if (( ${+ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
             (( ABBR_DEBUG )) && 'builtin' 'echo' "  Found a regular session abbreviation"
             abbreviations_sets+=( ABBR_REGULAR_SESSION_ABBREVIATIONS )
           fi
@@ -151,7 +151,7 @@ _abbr() {
             source ${ABBR_TMPDIR}global-user-abbreviations
           fi
 
-          if (( ${+ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]} )); then
+          if (( ${+ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
             (( ABBR_DEBUG )) && 'builtin' 'echo' "  Found a global user abbreviation"
             abbreviations_sets+=( ABBR_GLOBAL_USER_ABBREVIATIONS )
           fi
@@ -162,7 +162,7 @@ _abbr() {
             source ${ABBR_TMPDIR}regular-user-abbreviations
           fi
 
-          if (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} )); then
+          if (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
             (( ABBR_DEBUG )) && 'builtin' 'echo' "  Found a regular user abbreviation"
             abbreviations_sets+=( ABBR_REGULAR_USER_ABBREVIATIONS )
           fi
@@ -467,11 +467,11 @@ _abbr() {
         if [[ $type == 'global' ]]; then
           typed_scope=$(_abbr:util_set_to_typed_scope ABBR_GLOBAL_SESSION_ABBREVIATIONS)
 
-          if ! (( ${+ABBR_GLOBAL_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
+          if ! (( ${+ABBR_GLOBAL_SESSION_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]} )); then
             _abbr:util_check_command $abbreviation || return
 
             if ! (( dry_run )); then
-              ABBR_GLOBAL_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]=$expansion
+              ABBR_GLOBAL_SESSION_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]=$expansion
             fi
 
             success=1
@@ -479,11 +479,11 @@ _abbr() {
         else
           typed_scope=$(_abbr:util_set_to_typed_scope ABBR_REGULAR_SESSION_ABBREVIATIONS)
 
-          if ! (( ${+ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
+          if ! (( ${+ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]} )); then
             _abbr:util_check_command $abbreviation || return
 
             if ! (( dry_run )); then
-              ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]=$expansion
+              ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]=$expansion
             fi
 
             success=1
@@ -497,11 +497,11 @@ _abbr() {
             source ${ABBR_TMPDIR}global-user-abbreviations
           fi
 
-          if ! (( ${+ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
+          if ! (( ${+ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]} )); then
             _abbr:util_check_command $abbreviation || return
 
             if ! (( dry_run )); then
-              ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)abbreviation}]=$expansion
+              ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]=$expansion
               _abbr:util_sync_user
             fi
 
@@ -514,12 +514,12 @@ _abbr() {
             source ${ABBR_TMPDIR}regular-user-abbreviations
           fi
 
-          if ! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
+          if ! (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]} )); then
             _abbr:util_check_command $abbreviation || return
             typed_scope=$(_abbr:util_set_to_typed_scope ABBR_REGULAR_USER_ABBREVIATIONS)
 
             if ! (( dry_run )); then
-              ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]=$expansion
+              ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]=$expansion
               _abbr:util_sync_user
             fi
 
@@ -1281,7 +1281,7 @@ _abbr_widget_expand() {
   local preceding_lbuffer
   local -a words
 
-  expansion=$(_abbr_cmd_expansion ${(qqq)LBUFFER})
+  expansion=$(_abbr_cmd_expansion "$LBUFFER")
 
   if [[ -n $expansion ]]; then
     LBUFFER=${(Q)expansion}

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -427,15 +427,15 @@ _abbr() {
 
       if [[ $scope == 'session' ]]; then
         if [[ $type == 'global' ]]; then
-          expansion=${ABBR_GLOBAL_SESSION_ABBREVIATIONS[$current_abbreviation]}
+          expansion=${ABBR_GLOBAL_SESSION_ABBREVIATIONS[${(qqq)current_abbreviation}]}
         else
-          expansion=${ABBR_REGULAR_SESSION_ABBREVIATIONS[$current_abbreviation]}
+          expansion=${ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)current_abbreviation}]}
         fi
       else
         if [[ $type == 'global' ]]; then
-          expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[$current_abbreviation]}
+          expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)current_abbreviation}]}
         else
-          expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[$current_abbreviation]}
+          expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)current_abbreviation}]}
         fi
       fi
 

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -1151,7 +1151,7 @@ _abbr_job_push() {
       'builtin' 'echo' "abbr: A job added at $(strftime '%T %b %d %Y' ${next_job%.*}) has timed out."
       'builtin' 'echo' "The job was related to $(cat $next_job_path)."
       'builtin' 'echo' "This could be the result of manually terminating an abbr activity, for example during session startup."
-      'builtin' 'echo' "If you believe it reflects a abbr bug, please report it at https://github.com/olets/zsh-abbr/issues/new"
+      'builtin' 'echo' "If you believe it reflects an abbr bug, please report it at https://github.com/olets/zsh-abbr/issues/new"
       'builtin' 'echo'
 
       'command' 'rm' $next_job_path &>/dev/null

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -174,7 +174,7 @@ _abbr() {
       fi
 
       if ! (( ${#abbreviations_sets} )); then
-        _abbr:util_error "abbr erase: No${type:+ $type}${scope:+ $scope} abbreviation \`$abbreviation\` found"
+        _abbr:util_error "abbr erase: No${type:+ $type}${scope:+ $scope} abbreviation \`${(Q)abbreviation}\` found"
       elif [[ ${#abbreviations_sets} == 1 ]]; then
         verb_phrase="Would erase"
 
@@ -187,12 +187,12 @@ _abbr() {
           fi
         fi
 
-        _abbr:util_log_unless_quiet "$success_color$verb_phrase$reset_color $(_abbr:util_set_to_typed_scope $abbreviations_sets) \`$abbreviation\`"
+        _abbr:util_log_unless_quiet "$success_color$verb_phrase$reset_color $(_abbr:util_set_to_typed_scope $abbreviations_sets) \`${(Q)abbreviation}\`"
       else
         verb_phrase="Did not erase"
         (( dry_run )) && verb_phrase="Would not erase"
 
-        message="$error_color$verb_phrase$reset_color abbreviation \`$abbreviation\`. Please specify one of\\n"
+        message="$error_color$verb_phrase$reset_color abbreviation \`${(Q)abbreviation}\`. Please specify one of\\n"
 
         for abbreviations_set in $abbreviations_sets; do
           message+="  $(_abbr:util_set_to_typed_scope $abbreviations_set)\\n"
@@ -443,7 +443,7 @@ _abbr() {
         _abbr:util_add $new_abbreviation $expansion
         _abbr:erase $current_abbreviation
       else
-        _abbr:util_error "abbr rename: No${type:+ $type}${scope:+ $scope} abbreviation \`$current_abbreviation\` exists"
+        _abbr:util_error "abbr rename: No${type:+ $type}${scope:+ $scope} abbreviation \`${(Q)current_abbreviation}\` exists"
       fi
     }
 
@@ -463,7 +463,7 @@ _abbr() {
       success=0
 
       if [[ ${abbreviation%=*} != $abbreviation ]]; then
-        _abbr:util_error "abbr add: ABBREVIATION (\`$abbreviation\`) may not contain an equals sign"
+        _abbr:util_error "abbr add: ABBREVIATION (\`${(Q)abbreviation}\`) may not contain an equals sign"
         return
       fi
 
@@ -536,12 +536,12 @@ _abbr() {
         verb_phrase="Added"
         (( dry_run )) && verb_phrase="Would add"
 
-        _abbr:util_log_unless_quiet "$success_color$verb_phrase$reset_color the $typed_scope \`$abbreviation\`"
+        _abbr:util_log_unless_quiet "$success_color$verb_phrase$reset_color the $typed_scope \`${(Q)abbreviation}\`"
       else
         verb_phrase="Did not"
         (( dry_run )) && verb_phrase="Would not"
 
-        _abbr:util_error "$verb_phrase add the $typed_scope \`$abbreviation\` because it already exists"
+        _abbr:util_error "$verb_phrase add the $typed_scope \`${(Q)abbreviation}\` because it already exists"
       fi
     }
 
@@ -630,12 +630,12 @@ _abbr() {
           verb_phrase="will now expand"
           (( dry_run )) && verb_phrase="would now expand"
 
-          _abbr:util_log_unless_quieter "\`$abbreviation\` $verb_phrase as an abbreviation"
+          _abbr:util_log_unless_quieter "\`${(Q)abbreviation}\` $verb_phrase as an abbreviation"
         else
           verb_phrase="Did not"
           (( dry_run )) && verb_phrase="Would not"
 
-          _abbr:util_warn "$verb_phrase add the abbreviation \`$abbreviation\` because a command with the same name exists"
+          _abbr:util_warn "$verb_phrase add the abbreviation \`${(Q)abbreviation}\` because a command with the same name exists"
           return 1
         fi
       fi

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -753,15 +753,15 @@ _abbr() {
       user_updated=$(mktemp ${ABBR_TMPDIR}regular-user-abbreviations_updated.XXXXXX)
 
       typeset -p ABBR_GLOBAL_USER_ABBREVIATIONS > ${ABBR_TMPDIR}global-user-abbreviations
-      for abbreviation in ${(iko)ABBR_GLOBAL_USER_ABBREVIATIONS}; do
-        expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]}
-        'builtin' 'echo' "abbr -g ${abbreviation}=${(qqq)${(Q)expansion}}" >> "$user_updated"
+      for abbreviation in ${(ikoQ)ABBR_GLOBAL_USER_ABBREVIATIONS}; do
+        expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)abbreviation}]}
+        'builtin' 'echo' "abbr -g ${(qqq)${(Q)abbreviation}}=${(qqq)${(Q)expansion}}" >> "$user_updated"
       done
 
       typeset -p ABBR_REGULAR_USER_ABBREVIATIONS > ${ABBR_TMPDIR}regular-user-abbreviations
-      for abbreviation in ${(iko)ABBR_REGULAR_USER_ABBREVIATIONS}; do
-        expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]}
-        'builtin' 'echo' "abbr ${abbreviation}=${(qqq)${(Q)expansion}}" >> $user_updated
+      for abbreviation in ${(ikoQ)ABBR_REGULAR_USER_ABBREVIATIONS}; do
+        expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]}
+        'builtin' 'echo' "abbr ${(qqq)${(Q)abbreviation}}=${(qqq)${(Q)expansion}}" >> $user_updated
       done
 
       mv $user_updated $ABBR_USER_ABBREVIATIONS_FILE

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -1049,15 +1049,15 @@ _abbr_global_expansion() {
   local expansion
 
   abbreviation=$1
-  expansion=${ABBR_GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]}
+  expansion=${ABBR_GLOBAL_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]}
 
   if [[ ! $expansion ]]; then
     _abbr_create_files
     source ${ABBR_TMPDIR}global-user-abbreviations
-    expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]}
+    expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)abbreviation}]}
   fi
 
-  'builtin' 'echo' - $expansion
+  'builtin' 'echo' - ${(Q)expansion}
 }
 
 _abbr_init() {
@@ -1282,6 +1282,7 @@ _abbr_widget_expand() {
 
   local expansion
   local abbreviation
+  local -i i
   local preceding_lbuffer
   local -a words
 
@@ -1296,7 +1297,7 @@ _abbr_widget_expand() {
   
   while (( i < ${#words} )); do
     abbreviation=${words:$i}
-    expansion=$(_abbr_global_expansion $abbreviation)
+    expansion=$(_abbr_global_expansion "$abbreviation")
 
     if [[ -n $expansion ]]; then
       preceding_lbuffer=${LBUFFER%%$abbreviation}

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -93,7 +93,7 @@ _abbr() {
         abbreviation=${(q)abbreviation}
         expansion=${(q)expansion}
       fi
-
+      
       if [[ -z $abbreviation || -z $expansion || $abbreviation == $1 ]]; then
         _abbr:util_error "abbr add: Requires abbreviation and expansion"
         return
@@ -135,14 +135,14 @@ _abbr() {
 
       if [[ $scope != 'user' ]]; then
         if [[ $type != 'regular' ]]; then
-          if (( ${+ABBR_GLOBAL_SESSION_ABBREVIATIONS[$abbreviation]} )); then
+          if (( ${+ABBR_GLOBAL_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
             (( ABBR_DEBUG )) && 'builtin' 'echo' "  Found a global session abbreviation"
             abbreviations_sets+=( ABBR_GLOBAL_SESSION_ABBREVIATIONS )
           fi
         fi
 
         if [[ $type != 'global' ]]; then
-          if (( ${+ABBR_REGULAR_SESSION_ABBREVIATIONS[$abbreviation]} )); then
+          if (( ${+ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
             (( ABBR_DEBUG )) && 'builtin' 'echo' "  Found a regular session abbreviation"
             abbreviations_sets+=( ABBR_REGULAR_SESSION_ABBREVIATIONS )
           fi
@@ -155,7 +155,7 @@ _abbr() {
             source ${ABBR_TMPDIR}global-user-abbreviations
           fi
 
-          if (( ${+ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]} )); then
+          if (( ${+ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
             (( ABBR_DEBUG )) && 'builtin' 'echo' "  Found a global user abbreviation"
             abbreviations_sets+=( ABBR_GLOBAL_USER_ABBREVIATIONS )
           fi
@@ -166,7 +166,7 @@ _abbr() {
             source ${ABBR_TMPDIR}regular-user-abbreviations
           fi
 
-          if (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]} )); then
+          if (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]} )); then
             (( ABBR_DEBUG )) && 'builtin' 'echo' "  Found a regular user abbreviation"
             abbreviations_sets+=( ABBR_REGULAR_USER_ABBREVIATIONS )
           fi
@@ -180,7 +180,7 @@ _abbr() {
 
         if ! (( dry_run )); then
           verb_phrase="Erased"
-          unset "${abbreviations_sets}[${(b)abbreviation}]" # quotation marks required
+          unset "${abbreviations_sets}[${(b)${(qqq)abbreviation}}]" # quotation marks required
 
           if [[ $abbreviations_sets =~ USER ]]; then
             _abbr:util_sync_user

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -1012,7 +1012,7 @@ _abbr_cmd_expansion() {
     expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]}
   fi
 
-  'builtin' 'echo' - $expansion
+  'builtin' 'echo' - ${(Q)expansion}
 }
 
 _abbr_create_files() {
@@ -1281,7 +1281,7 @@ _abbr_widget_expand() {
   local preceding_lbuffer
   local -a words
 
-  expansion=$(_abbr_cmd_expansion $LBUFFER)
+  expansion=$(_abbr_cmd_expansion ${(qqq)LBUFFER})
 
   if [[ -n $expansion ]]; then
     LBUFFER=${(Q)expansion}

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -462,11 +462,6 @@ _abbr() {
       expansion=$2
       success=0
 
-      if [[ ${(w)#abbreviation} > 1 ]]; then
-        _abbr:util_error "abbr add: ABBREVIATION (\`$abbreviation\`) must be only one word"
-        return
-      fi
-
       if [[ ${abbreviation%=*} != $abbreviation ]]; then
         _abbr:util_error "abbr add: ABBREVIATION (\`$abbreviation\`) may not contain an equals sign"
         return

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -754,13 +754,13 @@ _abbr() {
 
       typeset -p ABBR_GLOBAL_USER_ABBREVIATIONS > ${ABBR_TMPDIR}global-user-abbreviations
       for abbreviation in ${(ikoQ)ABBR_GLOBAL_USER_ABBREVIATIONS}; do
-        expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)abbreviation}]}
+        expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]}
         'builtin' 'echo' "abbr -g ${(qqq)${(Q)abbreviation}}=${(qqq)${(Q)expansion}}" >> "$user_updated"
       done
 
       typeset -p ABBR_REGULAR_USER_ABBREVIATIONS > ${ABBR_TMPDIR}regular-user-abbreviations
       for abbreviation in ${(ikoQ)ABBR_REGULAR_USER_ABBREVIATIONS}; do
-        expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]}
+        expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]}
         'builtin' 'echo' "abbr ${(qqq)${(Q)abbreviation}}=${(qqq)${(Q)expansion}}" >> $user_updated
       done
 


### PR DESCRIPTION
For discussion see #32

Abbreviations can be more than one word

```shell
% abbr "git cp"="git cherry-pick"
% git cp<space>
# expands inline to `git cherry-pick`!

% abbr g=git
% g<space>fp<space>
# expands inline to `git cherry-pick`!
```
