### PR TITLE
respect XDG_CONFIG_HOME *for v5

### DIFF
--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -39,7 +39,7 @@ typeset -gi ABBR_QUIETER=${ABBR_QUIETER:-0}
 typeset -g ABBR_TMPDIR=${ABBR_TMPDIR:-${${TMPDIR:-/tmp}%/}/zsh-abbr/}
 
 # File abbreviations are stored in
-typeset -g ABBR_USER_ABBREVIATIONS_FILE=${ABBR_USER_ABBREVIATIONS_FILE:-$HOME/.config/zsh/abbreviations}
+typeset -g ABBR_USER_ABBREVIATIONS_FILE=${ABBR_USER_ABBREVIATIONS_FILE:-${XDG_CONFIG_HOME:-$HOME/.config}/zsh/abbreviations}
 
 # FUNCTIONS
 # ---------


### PR DESCRIPTION
- PR #57 but into `v5`

instead of hard-coding `$HOME/.config`, respect `XDG_CONFIG_HOME`, if available

