### PR TITLE
Add Fig as an installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ After adding the plugin to the manager, restart zsh:
 exec zsh
 ```
 
+### Fig
+
+Install `zsh-abbr` with [Fig](https://fig.io) in just one click.
+
+<a href="https://fig.io/plugins/other/zsh-abbr_olets" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
+
 ### Manual
 
 Clone this repo and add `source path/to/zsh-abbr.zsh` to your `.zshrc`. Then restart zsh:

--- a/README.md
+++ b/README.md
@@ -75,20 +75,13 @@ and follow the post-install instructions logged to the terminal.
 
 ### Plugin
 
-You can install zsh-abbr with a zsh plugin manager. Each has their own way of doing things. See your package manager's documentation or the [zsh plugin manager plugin installation procedures gist](https://gist.github.com/olets/06009589d7887617e061481e22cf5a4a).
+You can install zsh-abbr with a zsh plugin manager. Each has their own way of doing things. See your package manager's documentation or the [zsh plugin manager plugin installation procedures gist](https://gist.github.com/olets/06009589d7887617e061481e22cf5a4a); Fig users can install zsh-abbr from [its page in the Fig plugin directory](https://fig.io/plugins/other/zsh-abbr_olets).
 
 After adding the plugin to the manager, restart zsh:
 
 ```shell
 exec zsh
 ```
-
-### Fig
-
-Install `zsh-abbr` with [Fig](https://fig.io) in just one click.
-
-<a href="https://fig.io/plugins/other/zsh-abbr_olets" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
-
 
 ### Manual
 


### PR DESCRIPTION
We recently listed on `zsh-abbr` on [Fig Plugin Store](https://fig.io/plugins), so we'd love to have Fig displayed as a download method on your readme. Thanks so much and please let me know if you have any questions!