### PR TITLE
Allow to define cursor position after expansion

### DIFF
--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -1345,13 +1345,6 @@ _abbr_widget_expand_and_space() {
   else
     zle self-insert
   fi
-  _abbr_widget_trigger_syntax_highlighting
-}
-
-_abbr_widget_trigger_syntax_highlighting() {
-  if typeset -f _zsh_highlight > /dev/null; then
-      _zsh_highlight
-  fi
 }
 
 

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -51,7 +51,7 @@ if [[ -z $ABBR_USER_ABBREVIATIONS_FILE ]]; then
 fi
 
 # Cursor position marker after expansion
-typeset -g ABBR_CURSOR_MARKER=${ABBR_CURSOR_MARKER:-__CURSOR__}
+typeset -g ABBR_CURSOR_MARKER=${ABBR_CURSOR_MARKER:-__ABBR_CURSOR__}
 
 # FUNCTIONS
 # ---------

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -1087,13 +1087,13 @@ _abbr_init() {
   typeset -g ABBR_PRECMD_MESSAGE
   typeset -gA ABBR_REGULAR_SESSION_ABBREVIATIONS
   typeset -gA ABBR_REGULAR_USER_ABBREVIATIONS
-  typeset -gi ABBR_NO_ADDITIONAL_SPACE
+  typeset -gi ABBR_SUPPRESS_SPACE
 
   ABBR_INITIALIZING=1
   ABBR_PRECMD_MESSAGE=
   ABBR_REGULAR_SESSION_ABBREVIATIONS=()
   ABBR_GLOBAL_SESSION_ABBREVIATIONS=()
-  ABBR_NO_ADDITIONAL_SPACE=0
+  ABBR_SUPPRESS_SPACE=0
 
   job_name=$(_abbr_job_name)
 
@@ -1299,9 +1299,9 @@ _abbr_set_cursor_position() {
     local buffer="${BUFFER}"
     LBUFFER="${buffer%%"$ABBR_CURSOR_MARKER"*}"
     RBUFFER="${buffer#*"$ABBR_CURSOR_MARKER"}"
-    ABBR_NO_ADDITIONAL_SPACE=1
+    ABBR_SUPPRESS_SPACE=1
   else
-    ABBR_NO_ADDITIONAL_SPACE=0
+    ABBR_SUPPRESS_SPACE=0
   fi
 }
 
@@ -1360,11 +1360,11 @@ _abbr_widget_expand_and_space() {
 
   _abbr_widget_expand
 
-  if [[ $ABBR_NO_ADDITIONAL_SPACE == 0 ]]; then
+  if [[ $ABBR_SUPPRESS_SPACE == 0 ]]; then
     zle self-insert
   fi
 
-  ABBR_NO_ADDITIONAL_SPACE=0
+  ABBR_SUPPRESS_SPACE=0
 }
 
 

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -1295,13 +1295,10 @@ _abbr_precmd() {
 _abbr_set_cursor_position() {
   emulate -LR zsh
 
-  local buffer_arr
-
   if [[ "${BUFFER}" =~ "${ABBR_CURSOR_MARKER}" ]]; then
-    IFS=${ABBR_CURSOR_MARKER} read -rA buffer_arr <<< "${BUFFER}"
-    buffer_arr=(${buffer_arr})
-    RBUFFER=${buffer_arr[2]}
-    LBUFFER=${buffer_arr[1]}
+    local buffer="${BUFFER}"
+    LBUFFER="${buffer%%"$ABBR_CURSOR_MARKER"*}"
+    RBUFFER="${buffer#*"$ABBR_CURSOR_MARKER"}"
     ABBR_NO_ADDITIONAL_SPACE=1
   else
     ABBR_NO_ADDITIONAL_SPACE=0

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -42,7 +42,7 @@ if [[ -z $ABBR_USER_ABBREVIATIONS_FILE ]]; then
   # Respect XDG_CONFIG_HOME with a caveat:
   # Users with XDG_CONFIG_HOME defined who have been using zsh-abbr with the
   # default ABBR_USER_ABBREVIATIONS_FILE will already have a file in $HOME/.config
-  
+
   ABBR_USER_ABBREVIATIONS_FILE=$HOME/.config/zsh/abbreviations
 
   if [[ ! -f ABBR_USER_ABBREVIATIONS_FILE && -n $XDG_CONFIG_HOME && -d $XDG_CONFIG_HOME ]]; then
@@ -1338,7 +1338,13 @@ _abbr_widget_expand_and_space() {
   emulate -LR zsh
 
   _abbr_widget_expand
-  zle self-insert
+  if [[ "${BUFFER}" =~ "__CURSOR__" ]]
+  then
+    RBUFFER=${LBUFFER[(ws:__CURSOR__:)2]}
+    LBUFFER=${LBUFFER[(ws:__CURSOR__:)1]}
+  else
+    zle self-insert
+  fi
 }
 
 

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -1345,6 +1345,13 @@ _abbr_widget_expand_and_space() {
   else
     zle self-insert
   fi
+  _abbr_widget_trigger_syntax_highlighting
+}
+
+_abbr_widget_trigger_syntax_highlighting() {
+  if typeset -f _zsh_highlight > /dev/null; then
+      _zsh_highlight
+  fi
 }
 
 


### PR DESCRIPTION
- With the keyword `__CURSOR__` one can specify the position of the cursor after expanding the abbreviation using space
  - e.g. `abbr ccr="conan create __CURSOR__ demo/testing"` places the cursor between `create` and `demo/testing` after the expansion (inspired by [stackoverflow](https://stackoverflow.com/questions/28573145/how-can-i-move-the-cursor-after-a-zsh-abbreviation))
  - can also be used to omit the trailing whitespace (e.g. `abbr trm="rm -rf /tmp/__CURSOR__`")