### PR TITLE
support setting ABBR_TMPDIR to a value that doesn't end in `/`

### DIFF
--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -36,7 +36,7 @@ typeset -gi ABBR_QUIET=${ABBR_QUIET:-0}
 typeset -gi ABBR_QUIETER=${ABBR_QUIETER:-0}
 
 # Temp files are stored in
-typeset -g ABBR_TMPDIR=${ABBR_TMPDIR:-${${TMPDIR:-/tmp}%/}/zsh-abbr-${UID:-${USER}}/}
+typeset -g ABBR_TMPDIR=${${ABBR_TMPDIR:-${${TMPDIR:-/tmp}%/}/zsh-abbr}%/}
 
 # The file abbreviations are stored in
 typeset -g ABBR_USER_ABBREVIATIONS_FILE=$ABBR_USER_ABBREVIATIONS_FILE
@@ -185,7 +185,7 @@ _abbr() {
       if [[ $scope != 'session' ]]; then
         if [[ $type != 'regular' ]]; then
           if ! (( ABBR_LOADING_USER_ABBREVIATIONS )); then
-            source ${ABBR_TMPDIR%/}/global-user-abbreviations
+            source ${ABBR_TMPDIR}/global-user-abbreviations
           fi
 
           if (( ${+ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]} )); then
@@ -196,7 +196,7 @@ _abbr() {
 
         if [[ $type != 'global' ]]; then
           if ! (( ABBR_LOADING_USER_ABBREVIATIONS )); then
-            source ${ABBR_TMPDIR%/}/regular-user-abbreviations
+            source ${ABBR_TMPDIR}/regular-user-abbreviations
           fi
 
           if (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]} )); then
@@ -544,13 +544,13 @@ _abbr() {
           abbreviations_set=ABBR_GLOBAL_USER_ABBREVIATIONS
 
           if ! (( ABBR_LOADING_USER_ABBREVIATIONS )); then
-            source ${ABBR_TMPDIR%/}/global-user-abbreviations
+            source ${ABBR_TMPDIR}/global-user-abbreviations
           fi
         else
           abbreviations_set=ABBR_REGULAR_USER_ABBREVIATIONS
 
           if ! (( ABBR_LOADING_USER_ABBREVIATIONS )); then
-            source ${ABBR_TMPDIR%/}/regular-user-abbreviations
+            source ${ABBR_TMPDIR}/regular-user-abbreviations
           fi
         fi
       fi
@@ -793,15 +793,15 @@ _abbr() {
       local expansion
       local user_updated
 
-      user_updated=$(mktemp ${ABBR_TMPDIR%/}/regular-user-abbreviations_updated.XXXXXX)
+      user_updated=$(mktemp ${ABBR_TMPDIR}/regular-user-abbreviations_updated.XXXXXX)
 
-      typeset -p ABBR_GLOBAL_USER_ABBREVIATIONS > ${ABBR_TMPDIR%/}/global-user-abbreviations
+      typeset -p ABBR_GLOBAL_USER_ABBREVIATIONS > ${ABBR_TMPDIR}/global-user-abbreviations
       for abbreviation in ${(iko)ABBR_GLOBAL_USER_ABBREVIATIONS}; do
         expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]}
         'builtin' 'echo' "abbr -g $abbreviation=$expansion" >> "$user_updated"
       done
 
-      typeset -p ABBR_REGULAR_USER_ABBREVIATIONS > ${ABBR_TMPDIR%/}/regular-user-abbreviations
+      typeset -p ABBR_REGULAR_USER_ABBREVIATIONS > ${ABBR_TMPDIR}/regular-user-abbreviations
       for abbreviation in ${(iko)ABBR_REGULAR_USER_ABBREVIATIONS}; do
         expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]}
         'builtin' 'echo' "abbr $abbreviation=$expansion" >> $user_updated
@@ -1064,7 +1064,7 @@ _abbr_regular_expansion() {
 
   if [[ ! $expansion ]]; then
     _abbr_create_files
-    source ${ABBR_TMPDIR%/}/regular-user-abbreviations
+    source ${ABBR_TMPDIR}/regular-user-abbreviations
     expansion=$ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]
   fi
 
@@ -1078,9 +1078,9 @@ _abbr_create_files() {
 
   [[ -d $ABBR_TMPDIR ]] || mkdir -p $ABBR_TMPDIR
 
-  [[ -f ${ABBR_TMPDIR%/}/regular-user-abbreviations ]] || touch ${ABBR_TMPDIR%/}/regular-user-abbreviations
+  [[ -f ${ABBR_TMPDIR}/regular-user-abbreviations ]] || touch ${ABBR_TMPDIR}/regular-user-abbreviations
 
-  [[ -f ${ABBR_TMPDIR%/}/global-user-abbreviations ]] || touch ${ABBR_TMPDIR%/}/global-user-abbreviations
+  [[ -f ${ABBR_TMPDIR}/global-user-abbreviations ]] || touch ${ABBR_TMPDIR}/global-user-abbreviations
 }
 
 _abbr_debugger() {
@@ -1105,7 +1105,7 @@ _abbr_global_expansion() {
 
   if [[ ! $expansion ]]; then
     _abbr_create_files
-    source ${ABBR_TMPDIR%/}/global-user-abbreviations
+    source ${ABBR_TMPDIR}/global-user-abbreviations
     expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)abbreviation}]}
   fi
 
@@ -1160,7 +1160,7 @@ _abbr_job_pop() {
 
   job_name=$1
 
-  'command' 'rm' ${ABBR_TMPDIR%/}/jobs/$job_name &>/dev/null
+  'command' 'rm' ${ABBR_TMPDIR}/jobs/$job_name &>/dev/null
 }
 
 _abbr_job_push() {
@@ -1184,23 +1184,23 @@ _abbr_job_push() {
     function _abbr_job_push:add_job() {
       _abbr_debugger
 
-      if ! [[ -d ${ABBR_TMPDIR%/}/jobs ]]; then
-        mkdir -p ${ABBR_TMPDIR%/}/jobs
+      if ! [[ -d ${ABBR_TMPDIR}/jobs ]]; then
+        mkdir -p ${ABBR_TMPDIR}/jobs
       fi
 
-      'builtin' 'echo' $job_description > ${ABBR_TMPDIR%/}/jobs/$job_name
+      'builtin' 'echo' $job_description > ${ABBR_TMPDIR}/jobs/$job_name
     }
 
     function _abbr_job_push:next_job_name() {
       # cannot support debug message
 
-      'command' 'ls' -t ${ABBR_TMPDIR%/}/jobs | tail -1
+      'command' 'ls' -t ${ABBR_TMPDIR}/jobs | tail -1
     }
 
     function _abbr_job_push:handle_timeout() {
       _abbr_debugger
 
-      next_job_path=${ABBR_TMPDIR%/}/jobs/$next_job
+      next_job_path=${ABBR_TMPDIR}/jobs/$next_job
 
       'builtin' 'echo' "abbr: A job added at $(strftime '%T %b %d %Y' ${next_job%.*}) has timed out."
       'builtin' 'echo' "The job was related to $(cat $next_job_path)."
@@ -1299,8 +1299,8 @@ _abbr_load_user_abbreviations() {
         touch $ABBR_USER_ABBREVIATIONS_FILE
       fi
 
-      typeset -p ABBR_REGULAR_USER_ABBREVIATIONS > ${ABBR_TMPDIR%/}/regular-user-abbreviations
-      typeset -p ABBR_GLOBAL_USER_ABBREVIATIONS > ${ABBR_TMPDIR%/}/global-user-abbreviations
+      typeset -p ABBR_REGULAR_USER_ABBREVIATIONS > ${ABBR_TMPDIR}/regular-user-abbreviations
+      typeset -p ABBR_GLOBAL_USER_ABBREVIATIONS > ${ABBR_TMPDIR}/global-user-abbreviations
     }
 
     ABBR_LOADING_USER_ABBREVIATIONS=1

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -36,7 +36,7 @@ typeset -gi ABBR_QUIET=${ABBR_QUIET:-0}
 typeset -gi ABBR_QUIETER=${ABBR_QUIETER:-0}
 
 # Temp files are stored in
-typeset -g ABBR_TMPDIR=${${ABBR_TMPDIR:-${${TMPDIR:-/tmp}%/}/zsh-abbr}%/}
+typeset -g ABBR_TMPDIR=${${ABBR_TMPDIR:-${${TMPDIR:-/tmp}%/}/zsh-abbr}%/}/
 
 # The file abbreviations are stored in
 typeset -g ABBR_USER_ABBREVIATIONS_FILE=$ABBR_USER_ABBREVIATIONS_FILE
@@ -185,7 +185,7 @@ _abbr() {
       if [[ $scope != 'session' ]]; then
         if [[ $type != 'regular' ]]; then
           if ! (( ABBR_LOADING_USER_ABBREVIATIONS )); then
-            source ${ABBR_TMPDIR}/global-user-abbreviations
+            source ${ABBR_TMPDIR}global-user-abbreviations
           fi
 
           if (( ${+ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]} )); then
@@ -196,7 +196,7 @@ _abbr() {
 
         if [[ $type != 'global' ]]; then
           if ! (( ABBR_LOADING_USER_ABBREVIATIONS )); then
-            source ${ABBR_TMPDIR}/regular-user-abbreviations
+            source ${ABBR_TMPDIR}regular-user-abbreviations
           fi
 
           if (( ${+ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)${(Q)abbreviation}}]} )); then
@@ -544,13 +544,13 @@ _abbr() {
           abbreviations_set=ABBR_GLOBAL_USER_ABBREVIATIONS
 
           if ! (( ABBR_LOADING_USER_ABBREVIATIONS )); then
-            source ${ABBR_TMPDIR}/global-user-abbreviations
+            source ${ABBR_TMPDIR}global-user-abbreviations
           fi
         else
           abbreviations_set=ABBR_REGULAR_USER_ABBREVIATIONS
 
           if ! (( ABBR_LOADING_USER_ABBREVIATIONS )); then
-            source ${ABBR_TMPDIR}/regular-user-abbreviations
+            source ${ABBR_TMPDIR}regular-user-abbreviations
           fi
         fi
       fi
@@ -793,15 +793,15 @@ _abbr() {
       local expansion
       local user_updated
 
-      user_updated=$(mktemp ${ABBR_TMPDIR}/regular-user-abbreviations_updated.XXXXXX)
+      user_updated=$(mktemp ${ABBR_TMPDIR}regular-user-abbreviations_updated.XXXXXX)
 
-      typeset -p ABBR_GLOBAL_USER_ABBREVIATIONS > ${ABBR_TMPDIR}/global-user-abbreviations
+      typeset -p ABBR_GLOBAL_USER_ABBREVIATIONS > ${ABBR_TMPDIR}global-user-abbreviations
       for abbreviation in ${(iko)ABBR_GLOBAL_USER_ABBREVIATIONS}; do
         expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[$abbreviation]}
         'builtin' 'echo' "abbr -g $abbreviation=$expansion" >> "$user_updated"
       done
 
-      typeset -p ABBR_REGULAR_USER_ABBREVIATIONS > ${ABBR_TMPDIR}/regular-user-abbreviations
+      typeset -p ABBR_REGULAR_USER_ABBREVIATIONS > ${ABBR_TMPDIR}regular-user-abbreviations
       for abbreviation in ${(iko)ABBR_REGULAR_USER_ABBREVIATIONS}; do
         expansion=${ABBR_REGULAR_USER_ABBREVIATIONS[$abbreviation]}
         'builtin' 'echo' "abbr $abbreviation=$expansion" >> $user_updated
@@ -1064,7 +1064,7 @@ _abbr_regular_expansion() {
 
   if [[ ! $expansion ]]; then
     _abbr_create_files
-    source ${ABBR_TMPDIR}/regular-user-abbreviations
+    source ${ABBR_TMPDIR}regular-user-abbreviations
     expansion=$ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]
   fi
 
@@ -1078,9 +1078,9 @@ _abbr_create_files() {
 
   [[ -d $ABBR_TMPDIR ]] || mkdir -p $ABBR_TMPDIR
 
-  [[ -f ${ABBR_TMPDIR}/regular-user-abbreviations ]] || touch ${ABBR_TMPDIR}/regular-user-abbreviations
+  [[ -f ${ABBR_TMPDIR}regular-user-abbreviations ]] || touch ${ABBR_TMPDIR}regular-user-abbreviations
 
-  [[ -f ${ABBR_TMPDIR}/global-user-abbreviations ]] || touch ${ABBR_TMPDIR}/global-user-abbreviations
+  [[ -f ${ABBR_TMPDIR}global-user-abbreviations ]] || touch ${ABBR_TMPDIR}global-user-abbreviations
 }
 
 _abbr_debugger() {
@@ -1105,7 +1105,7 @@ _abbr_global_expansion() {
 
   if [[ ! $expansion ]]; then
     _abbr_create_files
-    source ${ABBR_TMPDIR}/global-user-abbreviations
+    source ${ABBR_TMPDIR}global-user-abbreviations
     expansion=${ABBR_GLOBAL_USER_ABBREVIATIONS[${(qqq)abbreviation}]}
   fi
 
@@ -1160,7 +1160,7 @@ _abbr_job_pop() {
 
   job_name=$1
 
-  'command' 'rm' ${ABBR_TMPDIR}/jobs/$job_name &>/dev/null
+  'command' 'rm' ${ABBR_TMPDIR}jobs/$job_name &>/dev/null
 }
 
 _abbr_job_push() {
@@ -1184,23 +1184,23 @@ _abbr_job_push() {
     function _abbr_job_push:add_job() {
       _abbr_debugger
 
-      if ! [[ -d ${ABBR_TMPDIR}/jobs ]]; then
-        mkdir -p ${ABBR_TMPDIR}/jobs
+      if ! [[ -d ${ABBR_TMPDIR}jobs ]]; then
+        mkdir -p ${ABBR_TMPDIR}jobs
       fi
 
-      'builtin' 'echo' $job_description > ${ABBR_TMPDIR}/jobs/$job_name
+      'builtin' 'echo' $job_description > ${ABBR_TMPDIR}jobs/$job_name
     }
 
     function _abbr_job_push:next_job_name() {
       # cannot support debug message
 
-      'command' 'ls' -t ${ABBR_TMPDIR}/jobs | tail -1
+      'command' 'ls' -t ${ABBR_TMPDIR}jobs | tail -1
     }
 
     function _abbr_job_push:handle_timeout() {
       _abbr_debugger
 
-      next_job_path=${ABBR_TMPDIR}/jobs/$next_job
+      next_job_path=${ABBR_TMPDIR}jobs/$next_job
 
       'builtin' 'echo' "abbr: A job added at $(strftime '%T %b %d %Y' ${next_job%.*}) has timed out."
       'builtin' 'echo' "The job was related to $(cat $next_job_path)."
@@ -1299,8 +1299,8 @@ _abbr_load_user_abbreviations() {
         touch $ABBR_USER_ABBREVIATIONS_FILE
       fi
 
-      typeset -p ABBR_REGULAR_USER_ABBREVIATIONS > ${ABBR_TMPDIR}/regular-user-abbreviations
-      typeset -p ABBR_GLOBAL_USER_ABBREVIATIONS > ${ABBR_TMPDIR}/global-user-abbreviations
+      typeset -p ABBR_REGULAR_USER_ABBREVIATIONS > ${ABBR_TMPDIR}regular-user-abbreviations
+      typeset -p ABBR_GLOBAL_USER_ABBREVIATIONS > ${ABBR_TMPDIR}global-user-abbreviations
     }
 
     ABBR_LOADING_USER_ABBREVIATIONS=1


### PR DESCRIPTION
Changes:
- Handle ABBR_TMPDIR values with or without trailing slash
- Create separate ABBR_TEMP per $UID or $USER (inspired by another user workaround on #54)
- chore: Remove (by vscode) trailing whitespaces in the file

Tested on Debian and MacOS.