### PR TITLE
command completion [for #104]

### DIFF
--- a/completions/_abbr
+++ b/completions/_abbr
@@ -156,7 +156,7 @@ case $state in
         # [<SCOPE>] [<TYPE>] [--dry-run] [(--quiet | --quieter)] [(-f | --force)] [--file <config-file>] [--prefix <ABBREVIATION prefix>]
         _arguments \
           "(--dry-run)--dry-run[see what would result, without making any actual changes]" \
-          "(--file)--file[path to a Git config file]" \
+          "(--file)--file[path to a Git config file]:file:_files -/" \
           "(-f)-f[ignore warnings]" \
           "(--force)--force[ignore warnings]" \
           "(-g)-g[expand everywhere]" \

--- a/completions/_abbr
+++ b/completions/_abbr
@@ -1,0 +1,202 @@
+#compdef abbr
+# ------------------------------------------------------------------------------
+#  Completion script for zsh-abbr
+#
+# https://github.com/olets/zsh-abbr
+# v5.1.0
+# Copyright (c) 2019-present Henry Bley-Vroman
+#
+# Licensed under the same license as zsh-abbr. See zsh-abbr's LICENSE file
+#
+# ------------------------------------------------------------------------------
+
+
+local state line ret=1
+
+_arguments -C \
+    '1: :->cmds' \
+    '*:: :->args' && ret=0
+
+case $state in
+	cmds)
+		_values "abbr command" \
+      "a[Add a new abbreviation.]" \
+      "add[Add a new abbreviation.]" \
+      "c[Erase all session abbreviations.]" \
+      "clear-session[Erase all session abbreviations.]" \
+      "e[Erase an abbreviation.]" \
+      "erase[Erase an abbreviation.]" \
+      "x[Output the ABBREVIATION's EXPANSION.]" \
+      "expand[Output the ABBREVIATION's EXPANSION.]" \
+      "export-aliases[Export abbreviations as alias commands.]" \
+      "g[Add a regular abbreviation, the expansion of which is prefixed with git; and add a global abbreviation, the abbreviation and expansion of which are prefixed with git.]" \
+      "git[Add a regular abbreviation, the expansion of which is prefixed with git; and add a global abbreviation, the abbreviation and expansion of which are prefixed with git.]" \
+			"help[Show the manpage.]" \
+			"--help[Show the manpage.]" \
+			"import-aliases[Add regular abbreviations for every regular alias in the session, and global abbreviations for every global alias in the session.]" \
+			"import-fish[Import fish abbr-syntax abbreviations.]" \
+			"import-git-aliases[Add regular abbreviations for every Git alias in the current session. The EXPANSION is prefixed with git\[Space\].]" \
+      "list[List the abbreviations with their expansions.]" \
+      "l[List the abbreviations only.]" \
+      "list-abbreviations[List the abbreviations only.]" \
+      "list-commands[List as commands suitable for export.]" \
+      "profile[Log profile information for debugging.]" \
+      "R[Rename an abbreviation.]" \
+      "rename[Rename an abbreviation.]" \
+			"version[Show the current version.]" \
+			"-v[Show the current version.]" \
+			"--version[Show the current version.]"
+		ret=0
+		;;
+	args)
+		case $line[1] in
+      a|\
+      add)
+        # [<SCOPE>] [<TYPE>] [--dry-run] [(--quiet | --quieter)] [(-f | --force)] ABBREVIATION=EXPANSION
+        _arguments \
+          "(--dry-run)--dry-run[see what would result, without making any actual changes]" \
+          "(-f)-f[ignore warnings]" \
+          "(--force)--force[ignore warnings]" \
+          "(-g)-g[expand everywhere]" \
+          "(--global)--global[expand everywhere]" \
+          "(-q)-q[silence success output]" \
+          "(--qq)--qq[silence success output and warnings]" \
+          "(--quiet)--quiet[silence success output]" \
+          "(--quieter)--quieter[silence success output and warnings]" \
+          "(-r)-r[expand at the start of the line]" \
+          "(--regular)--regular[expand at the start of the line]" \
+          "(-S)-S[available in this session]" \
+          "(--session)--session[available in this session]" \
+          "(-U)-U[available in all sessions]" \
+          "(--user)--user[available in all sessions]"
+        ret=0
+        ;;
+      e|\
+      erase)
+        # [<SCOPE>] [<TYPE>] [--dry-run] [--quiet] ABBREVIATION
+        _arguments \
+          "(--dry-run)--dry-run[see what would result, without making any actual changes]" \
+          "(-g)-g[expand everywhere]" \
+          "(--global)--global[expand everywhere]" \
+          "(-q)-q[silence success output]" \
+          "(--quiet)--quiet[silence success output]" \
+          "(-r)-r[expand at the start of the line]" \
+          "(--regular)--regular[expand at the start of the line]" \
+          "(-S)-S[available in this session]" \
+          "(--session)--session[available in this session]" \
+          "(-U)-U[available in all sessions]" \
+          "(--user)--user[available in all sessions]"
+        ret=0
+        ;;
+      export-aliases|\
+      list|\
+      l|\
+      list-abbreviations|\
+      L|\
+      list-commands)
+        # [<SCOPE>] [<TYPE>]
+        _arguments \
+          "(--global)--global[expand everywhere]" \
+          "(-g)-g[expand everywhere]" \
+          "(-r)-r[expand at the start of the line]" \
+          "(--regular)--regular[expand at the start of the line]" \
+          "(-S)-S[available in this session]" \
+          "(--session)--session[available in all sessions]" \
+          "(--user)--user[available in all sessions]" \
+          "(-U)-U[available in all sessions]"
+          ;;
+      git)
+        # [<SCOPE>] [--dry-run] [(--quiet | --quieter)] [(-f | --force)] ABBREVIATION=EXPANSION
+        _arguments \
+          "(--dry-run)--dry-run[see what would result, without making any actual changes]" \
+          "(-f)-f[ignore warnings]" \
+          "(--force)--force[ignore warnings]" \
+          "(-q)-q[silence success output]" \
+          "(--qq)--qq[silence success output and warnings]" \
+          "(--quiet)--quiet[silence success output]" \
+          "(--quieter)--quieter[silence success output and warnings]" \
+          "(-S)-S[available in this session]" \
+          "(--session)--session[available in all sessions]" \
+          "(-U)-U[available in all sessions]" \
+          "(--user)--user[available in all sessions]"
+        ret=0
+        ;;
+      import-aliases)
+        # [<TYPE>] [--dry-run] [(--quiet | --quieter)] [(-f | --force)]
+        _arguments \
+          "(--dry-run)--dry-run[see what would result, without making any actual changes]" \
+          "(-f)-f[ignore warnings]" \
+          "(--force)--force[ignore warnings]" \
+          "(-g)-g[expand everywhere]" \
+          "(--global)--global[expand everywhere]" \
+          "(-q)-q[silence success output]" \
+          "(--qq)--qq[silence success output and warnings]" \
+          "(--quiet)--quiet[silence success output]" \
+          "(--quieter)--quieter[silence success output and warnings]" \
+          "(-r)-r[expand at the start of the line]" \
+          "(--regular)--regular[expand at the start of the line]"
+          ;;
+      import-fish)
+        # [<SCOPE>] [--dry-run] [(--quiet | --quieter)] [(-f | --force)] FILE
+        _arguments \
+          "(--dry-run)--dry-run[see what would result, without making any actual changes]" \
+          "(-f)-f[ignore warnings]" \
+          "(--force)--force[ignore warnings]" \
+          "(-q)-q[silence success output]" \
+          "(--qq)--qq[silence success output and warnings]" \
+          "(--quiet)--quiet[silence success output]" \
+          "(--quieter)--quieter[silence success output and warnings]" \
+          "(-S)-S[available in this session]" \
+          "(--session)--session[available in this session]" \
+          "(-U)-U[available in all sessions]" \
+          "(--user)--user[available in all sessions]"
+        ret=0
+        ;;
+      import-git-aliases)
+        # [<SCOPE>] [<TYPE>] [--dry-run] [(--quiet | --quieter)] [(-f | --force)] [--file <config-file>] [--prefix <ABBREVIATION prefix>]
+        _arguments \
+          "(--dry-run)--dry-run[see what would result, without making any actual changes]" \
+          "(--file)--file[path to a Git config file]" \
+          "(-f)-f[ignore warnings]" \
+          "(--force)--force[ignore warnings]" \
+          "(-g)-g[expand everywhere]" \
+          "(--global)--global[expand everywhere]" \
+          "(-q)-q[silence success output]" \
+          "(--prefix)--prefix[prefix added to the ABBREVIATIONs]" \
+          "(--qq)--qq[silence success output and warnings]" \
+          "(--quiet)--quiet[silence success output]" \
+          "(--quieter)--quieter[silence success output and warnings]" \
+          "(-r)-r[expand at the start of the line]" \
+          "(--regular)--regular[expand at the start of the line]" \
+          "(-S)-S[available in this session]" \
+          "(--session)--session[available in all sessions]" \
+          "(-U)-U[available in all sessions]" \
+          "(--user)--user[available in all sessions]"
+        ret=0
+        ;;
+      R|\
+      rename)
+        # [<SCOPE>] [<TYPE>] [--dry-run] [(--quiet | --quieter)] [(-f | --force)] OLD NEW
+        _arguments \
+          "(--dry-run)--dry-run[see what would result, without making any actual changes]" \
+          "(-f)-f[ignore warnings]" \
+          "(--force)--force[ignore warnings]" \
+          "(-g)-g[expand everywhere]" \
+          "(--global)--global[expand everywhere]" \
+          "(-q)-q[silence success output]" \
+          "(--qq)--qq[silence success output and warnings]" \
+          "(--quiet)--quiet[silence success output]" \
+          "(--quieter)--quieter[silence success output and warnings]" \
+          "(-r)-r[expand at the start of the line]" \
+          "(--regular)--regular[expand at the start of the line]" \
+          "(-S)-S[available in this session]" \
+          "(--session)--session[available in this session]" \
+          "(-U)-U[available in all sessions]" \
+          "(--user)--user[available in all sessions]"
+        ret=0
+        ;;
+    esac
+    ;;
+esac
+
+return ret

--- a/zsh-abbr.plugin.zsh
+++ b/zsh-abbr.plugin.zsh
@@ -1,1 +1,2 @@
+fpath+=${0:A:h}/completions
 source ${0:A:h}/zsh-abbr.zsh

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -1144,14 +1144,6 @@ _abbr_init() {
         #   _abbr_warn_deprecation deprecated_fn fn
         #   fn
         # }
-        _abbr() {
-          emulate -LR zsh
-
-          _abbr_warn_deprecation _abbr
-          
-          abbr
-        }
-        
         _abbr:util_deprecated() {
           _abbr_warn_deprecation _abbr:util_deprecated
           _abbr:util_deprecated_deprecated


### PR DESCRIPTION
Closes #104

Add completion for `abbr` commands.

For example `abbr [TAB]` to see the available subcommands, or `abbr ad[TAB][TAB]` to complete `abbr add` and see the available flags.

⚠️ drops the `_abbr` alias for `abbr`

⚠️ Users who install zsh-abbr with Homebrew will not get completions yet. Soon…