### PR TITLE
cursor placement [#110, replaces pr #63]

### DIFF
--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -1126,7 +1126,7 @@ _abbr_init() {
       
       zle -N abbr-expand
       zle -N abbr-expand-and-accept
-      zle -N abbr-expand-and-space
+      zle -N abbr-expand-and-insert
     }
 
     _abbr_init:bind_widgets() {
@@ -1135,14 +1135,14 @@ _abbr_init() {
       _abbr_debugger
 
       # spacebar expands abbreviations
-      bindkey " " abbr-expand-and-space
+      bindkey " " abbr-expand-and-insert
 
       # control-spacebar is a normal space
       bindkey "^ " magic-space
 
       # when running an incremental search,
       # spacebar behaves normally and control-space expands abbreviations
-      bindkey -M isearch "^ " abbr-expand-and-space
+      bindkey -M isearch "^ " abbr-expand-and-insert
       bindkey -M isearch " " magic-space
 
       # enter key expands and accepts abbreviations
@@ -1155,13 +1155,14 @@ _abbr_init() {
 
         _abbr_debugger
 
-        # Deprecation notices for values that could not be meaningfully set after initialization
+        # START Deprecation notices for values that could not be meaningfully set after initialization
         # Example form:
         # (( ${+DEPRECATED_VAL} )) && _abbr_warn_deprecation DEPRECATED_VAL VAL
         # VAL=$DEPRECATED_VAL
         (( ABBR_PRECMD_LOGS != 1 )) && _abbr_warn_deprecation ABBR_PRECMD_LOGS
+        # END Deprecation notices for values that could not be meaningfully set after initialization
 
-        # Deprecation notices for functions
+        # START Deprecation notices for functions
         # Example form:
         # deprecated_fn() {
         #   _abbr_warn_deprecation deprecated_fn fn
@@ -1172,6 +1173,12 @@ _abbr_init() {
           _abbr:util_deprecated_deprecated
         }
 
+        abbr-expand-and-space() {
+          _abbr_warn_deprecation abbr-expand-and-space
+          abbr-expand-and-insert
+        }
+        # END Deprecation notices for functions
+
         _abbr_add_widgets() {
           emulate -LR zsh
 
@@ -1179,7 +1186,7 @@ _abbr_init() {
           
           zle -N abbr-expand
           zle -N abbr-expand-and-accept
-          zle -N abbr-expand-and-space
+          zle -N abbr-expand-and-insert
         }
 
         _abbr_bind_widgets() {
@@ -1188,14 +1195,14 @@ _abbr_init() {
           _abbr_warn_deprecation _abbr_bind_widgets
           
           # spacebar expands abbreviations
-          bindkey " " abbr-expand-and-space
+          bindkey " " abbr-expand-and-insert
 
           # control-spacebar is a normal space
           bindkey "^ " magic-space
 
           # when running an incremental search,
           # spacebar behaves normally and control-space expands abbreviations
-          bindkey -M isearch "^ " abbr-expand-and-space
+          bindkey -M isearch "^ " abbr-expand-and-insert
           bindkey -M isearch " " magic-space
 
           # enter key expands and accepts abbreviations
@@ -1533,7 +1540,7 @@ abbr-expand-and-accept() {
   zle accept-line
 }
 
-abbr-expand-and-space() {
+abbr-expand-and-insert() {
   emulate -LR zsh
 
   abbr-expand


### PR DESCRIPTION
## Features

- `abbr-expand-and-space` is deprecated. Use `abbr-expand-and-insert` instead
- If `ABBR_SET_EXPANSION_CURSOR` (default `0`) is non-zero, the expansion's first instance of `ABBR_EXPANSION_CURSOR_MARKER` (default `$ABBR_LINE_CURSOR_MARKER`) will be replaced with the cursor.
- If `ABBR_SET_LINE_CURSOR` (default `0`) is non-zero, and the cursor was not placed during expansion, the line's first instance of `ABBR_LINE_CURSOR_MARKER` (default `%`) will be replaced with the cursor

## Tips

1. Add the `ABBR_EXPANSION_CURSOR_MARKER` to end of an expansion to opt out of inserting a space
    ```shell
    % ABBR_SET_EXPANSION_CURSOR=1
    % abbr nospace=none%
    % nospace[SPACE] # expands to `none[CURSOR]`
    ```
2. Build "template-y" abbreviations by including multiple ABBR_LINE_CURSOR_MARKER's in an expansion
    ```shell
    % ABBR_SET_EXPANSION_CURSOR=1
    % ABBR_SET_LINE_CURSOR=1
    % abbr template="a%b % c%d"
    % template[SPACE] # expands to `a[CURSOR]b % c%d`
    % a[type xSPACE]b % c%d # cursor moves: `ax b [CURSOR] c %`
    % ax b [type ySPACE] c%d # cursor moves: `ax b y c [CURSOR]`
    % ax b y c [CURSOR]
    ```
3. If your expansions have `%`, consider changing `ABBR_LINE_CURSOR_MARKER` to `%ABBR_CURSOR%` or similar

## Acknowledgments

- Thanks to @burneyy in #63