### PR TITLE
Update readme to state that fish does not support persistent, interactive abbreviation creation anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For example, abbreviate `git checkout` as `co` (or even `c` or anything else). T
 
 Why? Like aliases, abbreviations **save keystrokes**. Unlike aliases, abbreviations can leave you with a **transparently understandable command history** ready for using on a different computer or sharing with a colleague. And where aliases can let you forget the full command, abbreviations may **help you learn** the full command even as you type the shortened version.
 
-Like **zsh's `alias`**, zsh-abbr supports **"regular"** (i.e. command-position) and **"global"** (anywhere on the line) abbreviations. Like **fish's `abbr`**, zsh-abbr supports **interactive creation** of persistent abbreviations which are immediately available in all terminal sessions. Abbreviations automatically **sync to a file**, ready for your dotfile management.
+Like **zsh's `alias`**, zsh-abbr supports **"regular"** (i.e. command-position) and **"global"** (anywhere on the line) abbreviations. Unlike **fish's `abbr`**, zsh-abbr supports **interactive creation** of persistent abbreviations which are immediately available in all terminal sessions. Abbreviations automatically **sync to a file**, ready for your dotfile management.
 
 Run `abbr help` for documentation; if the package is installed with Homebrew, `man abbr` is also available.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For example, abbreviate `git checkout` as `co` (or even `c` or anything else). T
 
 Why? Like aliases, abbreviations **save keystrokes**. Unlike aliases, abbreviations can leave you with a **transparently understandable command history** ready for using on a different computer or sharing with a colleague. And where aliases can let you forget the full command, abbreviations may **help you learn** the full command even as you type the shortened version.
 
-Like **zsh's `alias`**, zsh-abbr supports **"regular"** (i.e. command-position) and **"global"** (anywhere on the line) abbreviations. Unlike **fish's `abbr`**, zsh-abbr supports **interactive creation** of persistent abbreviations which are immediately available in all terminal sessions. Abbreviations automatically **sync to a file**, ready for your dotfile management.
+Like **zsh's `alias`**, zsh-abbr supports **"regular"** (i.e. command-position) and **"global"** (anywhere on the line) abbreviations. It also supports **interactive creation** of persistent abbreviations which are immediately available in all terminal sessions. Abbreviations automatically **sync to a file**, ready for your dotfile management.
 
 Run `abbr help` for documentation; if the package is installed with Homebrew, `man abbr` is also available.
 


### PR DESCRIPTION
Fish removed the ability to persist interactive abbreviation creation. 

https://github.com/fish-shell/fish-shell/issues/9865#issuecomment-1610632677