### PR TITLE
Fix test readme instructions

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -5,24 +5,24 @@ Requires [zsh-test-runner](https://github.com/olets/zsh-test-runner) v2.x.
 To run the test suite in the current shell,
 
 ```shell
-. ./index.ztr.zsh
+. tests/index.ztr.zsh
 ```
 
 To run a single command's tests in the current shell,
 
 ```shell
-. ./index.ztr.zsh <command> # e.g. `. ./index.ztr.zsh add`
+. tests/index.ztr.zsh <command> # e.g. `. tests/index.ztr.zsh add`
 ```
 
 To run the test suite in a subshell,
 
 ```shell
-ztr_path=$ZTR_PATH zsh ./index.ztr.zsh && abbr load
+ztr_path=$ZTR_PATH zsh tests/index.ztr.zsh && abbr load
 ```
 
 To run a single command's tests in a subshell,
 
 ```shell
-ztr_path=$ZTR_PATH zsh ./index.ztr.zsh <command> && abbr load
-# e.g. `ztr_path=$ZTR_PATH zsh ./index.ztr.zsh add && abbr load`
+ztr_path=$ZTR_PATH zsh tests/index.ztr.zsh <command> && abbr load
+# e.g. `ztr_path=$ZTR_PATH zsh tests/index.ztr.zsh add && abbr load`
 ```


### PR DESCRIPTION
The instructions in the test readme fail for me when I run them as instructed from within `tests/`. They work correctly when I run them from the repo root directory instead. Not sure if this is how it's supposed to be.