### PR TITLE
distinct tmpdir pathsfor users with and without privileges [#54]

### DIFF
--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -47,8 +47,12 @@ typeset -gi ABBR_SET_LINE_CURSOR=${ABBR_SET_LINE_CURSOR:-0}
 # In expansions, replace the first instance of ABBR_EXPANSION_CURSOR_MARKER with the cursor
 typeset -gi ABBR_SET_EXPANSION_CURSOR=${ABBR_SET_EXPANSION_CURSOR:-0}
 
-# Temp files are stored in
-typeset -g ABBR_TMPDIR=${ABBR_TMPDIR:-${${TMPDIR:-/tmp}%/}/zsh-abbr/}
+# The directory temp files are stored in
+if [[ ${(%):-%#} == '#' ]]; then
+  typeset -g ABBR_TMPDIR=${${ABBR_TMPDIR:-${${TMPDIR:-/tmp}%/}/zsh-abbr-privileged-users}%/}/
+else
+  typeset -g ABBR_TMPDIR=${${ABBR_TMPDIR:-${${TMPDIR:-/tmp}%/}/zsh-abbr}%/}/
+fi
 
 # The file abbreviations are stored in
 typeset -g ABBR_USER_ABBREVIATIONS_FILE=$ABBR_USER_ABBREVIATIONS_FILE


### PR DESCRIPTION
Returning to

- #54

and implementing the solution there, with one difference: the default tmpdir for users without privileges isn't renamed. Protects against weirdness in the first run, and against there being an extra directory sitting unused (it would get garbage collected, but still).