### PR TITLE
fix: arrange dependent expansions accordingly

### DIFF
--- a/tests/abbr-config.ztr.zsh
+++ b/tests/abbr-config.ztr.zsh
@@ -1,0 +1,10 @@
+#!/usr/bin/env zsh
+
+main() {
+	emulate -LR zsh
+
+	ztr test '[[ $ABBR_EXPANSION_CURSOR_MARKER == $ABBR_LINE_CURSOR_MARKER ]]' \
+		"Expansion cursor marker defaults to line cursor marker value"
+}
+
+main

--- a/tests/index.ztr.zsh
+++ b/tests/index.ztr.zsh
@@ -21,6 +21,8 @@ main() {
 	
 	local \
 		abbr_dir \
+		abbr_expansion_cursor_marker_saved \
+		abbr_line_cursor_marker_saved \
 		abbr_tmpdir_saved \
 		abbr_user_abbreviations_file_saved \
 		cmd \
@@ -61,11 +63,15 @@ main() {
 	fi
 
 	# Save user configuration
+	abbr_expansion_cursor_marker_saved=$ABBR_EXPANSION_CURSOR_MARKER
+	abbr_line_cursor_marker_saved=$ABBR_LINE_CURSOR_MARKER
 	abbr_quiet_saved=$ABBR_QUIET
 	abbr_tmpdir_saved=$ABBR_TMPDIR
 	abbr_user_abbreviations_file_saved=$ABBR_USER_ABBREVIATIONS_FILE
 
 	# Configure
+	unset ABBR_EXPANSION_CURSOR_MARKER
+	unset ABBR_LINE_CURSOR_MARKER
 	ABBR_QUIET=1
 	ABBR_USER_ABBREVIATIONS_FILE=$test_dir/abbreviations.$RANDOM.tmp
 	ABBR_TMPDIR=$test_tmpdir
@@ -100,6 +106,8 @@ main() {
 	rm -f $ABBR_USER_ABBREVIATIONS_FILE
 
 	# Reset
+	ABBR_EXPANSION_CURSOR_MARKER=$abbr_expansion_cursor_marker_saved
+	ABBR_LINE_CURSOR_MARKER=$abbr_line_cursor_marker_saved
 	ABBR_QUIET=$abbr_quiet_saved
 	ABBR_TMPDIR=$abbr_tmpdir_saved
 	ABBR_USER_ABBREVIATIONS_FILE=$abbr_user_abbreviations_file_saved

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -23,12 +23,14 @@ typeset -gi ABBR_DEFAULT_BINDINGS=${ABBR_DEFAULT_BINDINGS:-1}
 # Behave as if `--dry-run` was passed? (default false)
 typeset -gi ABBR_DRY_RUN=${ABBR_DRY_RUN:-0}
 
+# See ABBR_SET_LINE_CURSOR
+typeset -g ABBR_LINE_CURSOR_MARKER=${ABBR_LINE_CURSOR_MARKER:-%}
+
 # See ABBR_SET_EXPANSION_CURSOR
 typeset -g ABBR_EXPANSION_CURSOR_MARKER=${ABBR_EXPANSION_CURSOR_MARKER:-$ABBR_LINE_CURSOR_MARKER}
 
 # Behave as if `--force` was passed? (default false)
 typeset -gi ABBR_FORCE=${ABBR_FORCE:-0}
-
 
 # See ABBR_SET_LINE_CURSOR
 typeset -g ABBR_LINE_CURSOR_MARKER=${ABBR_LINE_CURSOR_MARKER:-%}


### PR DESCRIPTION
Commit [a97788d](https://github.com/olets/zsh-abbr/commit/a97788d03ed7a0a8342b4e31b6a08fb29e15ff3a) introduces a simple error by moving the definition of `ABBR_LINE_CURSOR_MARKER` below where it's read (by the `ABBR_EXPANSION_CURSOR_MARKER` definition).