### PR TITLE
prefixes for v6

### DIFF
--- a/tests/abbr-expand.ztr.zsh
+++ b/tests/abbr-expand.ztr.zsh
@@ -31,43 +31,58 @@ main() {
 			"Dependencies: erase"
 
 		abbr add $test_abbr_abbreviation=$test_abbr_expansion
-		ztr test '[[ $(abbr expand "$ABBR_REGULAR_ABBREVIATION_PREFIXES[1]$test_abbr_abbreviation") == "$ABBR_REGULAR_ABBREVIATION_PREFIXES[1]$test_abbr_expansion" ]]' \
+		ztr test '[[ $(abbr expand "$prefix_one_word$test_abbr_abbreviation") == "$prefix_one_word$test_abbr_expansion" ]]' \
 			"Can expand an abbreviation, prefixed with one word, in a script" \
 			"Dependencies: erase"
 
 		abbr add -S $test_abbr_abbreviation=$test_abbr_expansion
-		ztr test '[[ $(abbr expand "$ABBR_REGULAR_ABBREVIATION_PREFIXES[1]$test_abbr_abbreviation") == "$ABBR_REGULAR_ABBREVIATION_PREFIXES[1]$test_abbr_expansion" ]]' \
+		ztr test '[[ $(abbr expand "$prefix_one_word$test_abbr_abbreviation") == "$prefix_one_word$test_abbr_expansion" ]]' \
 			"Can expand a session abbreviation, prefixed with one word, in a script" \
 			"Dependencies: erase"
 
 		abbr add $test_abbr_abbreviation=$test_abbr_expansion
-		ztr test '[[ $(abbr expand "$ABBR_REGULAR_ABBREVIATION_PREFIXES[2]$test_abbr_abbreviation") == "$ABBR_REGULAR_ABBREVIATION_PREFIXES[2]$test_abbr_expansion" ]]' \
+		ztr test '[[ $(abbr expand "$prefix_multi_word$test_abbr_abbreviation") == "$prefix_multi_word$test_abbr_expansion" ]]' \
 			"Can expand an abbreviation, prefixed with multiple words, in a script" \
 			"Dependencies: erase"
 
 		abbr add -S $test_abbr_abbreviation=$test_abbr_expansion
-		ztr test '[[ $(abbr expand "$ABBR_REGULAR_ABBREVIATION_PREFIXES[2]$test_abbr_abbreviation") == "$ABBR_REGULAR_ABBREVIATION_PREFIXES[2]$test_abbr_expansion" ]]' \
+		ztr test '[[ $(abbr expand "$prefix_multi_word$test_abbr_abbreviation") == "$prefix_multi_word$test_abbr_expansion" ]]' \
 			"Can expand a session abbreviation, prefixed with multiple words, in a script" \
 			"Dependencies: erase"
 
 		abbr add $test_abbr_abbreviation=$test_abbr_expansion
-		ztr test '[[ $(abbr expand "$ABBR_REGULAR_ABBREVIATION_PREFIXES[3]$test_abbr_abbreviation") == "$ABBR_REGULAR_ABBREVIATION_PREFIXES[3]$test_abbr_expansion" ]]' \
+		ztr test '[[ $(abbr expand "$prefix_double_quotes$test_abbr_abbreviation") == "$prefix_double_quotes$test_abbr_expansion" ]]' \
 			"Can expand an abbreviation, prefixed with a prefix containing single-quoted double quotes, in a script" \
 			"Dependencies: erase"
 
 		abbr add -S $test_abbr_abbreviation=$test_abbr_expansion
-		ztr test '[[ $(abbr expand "$ABBR_REGULAR_ABBREVIATION_PREFIXES[3]$test_abbr_abbreviation") == "$ABBR_REGULAR_ABBREVIATION_PREFIXES[3]$test_abbr_expansion" ]]' \
+		ztr test '[[ $(abbr expand "$prefix_double_quotes$test_abbr_abbreviation") == "$prefix_double_quotes$test_abbr_expansion" ]]' \
 			"Can expand a session abbreviation, prefixed with a prefix containing single-quoted double quotes, in a script" \
 			"Dependencies: erase"
 
 		abbr add $test_abbr_abbreviation=$test_abbr_expansion
-		ztr test '[[ $(abbr expand "$ABBR_REGULAR_ABBREVIATION_PREFIXES[4]$test_abbr_abbreviation") == "$ABBR_REGULAR_ABBREVIATION_PREFIXES[4]$test_abbr_expansion" ]]' \
+		ztr test '[[ $(abbr expand "$prefix_single_quotes$test_abbr_abbreviation") == "$prefix_single_quotes$test_abbr_expansion" ]]' \
 			"Can expand an abbreviation, prefixed with a prefix containing double-quoted single quotes, in a script" \
 			"Dependencies: erase"
 
 		abbr add -S $test_abbr_abbreviation=$test_abbr_expansion
-		ztr test '[[ $(abbr expand "$ABBR_REGULAR_ABBREVIATION_PREFIXES[4]$test_abbr_abbreviation") == "$ABBR_REGULAR_ABBREVIATION_PREFIXES[4]$test_abbr_expansion" ]]' \
+		ztr test '[[ $(abbr expand "$prefix_single_quotes$test_abbr_abbreviation") == "$prefix_single_quotes$test_abbr_expansion" ]]' \
 			"Can expand a session abbreviation, prefixed with a prefix containing double-quoted single quotes, in a script" \
+			"Dependencies: erase"
+
+		abbr add $test_abbr_abbreviation=$test_abbr_expansion
+		ztr test '[[ $(abbr expand "$prefix_glob_match_1$test_abbr_abbreviation") == "$prefix_glob_match_1$test_abbr_expansion" ]]' \
+			"Can expand an abbreviation, prefixed with a glob, in a script — 1/n" \
+			"Dependencies: erase"
+
+		abbr add $test_abbr_abbreviation=$test_abbr_expansion
+		ztr test '[[ $(abbr expand "$prefix_glob_match_2$test_abbr_abbreviation") == "$prefix_glob_match_2$test_abbr_expansion" ]]' \
+			"Can expand an abbreviation, prefixed with a glob, in a script — 2/n" \
+			"Dependencies: erase"
+
+		abbr add $test_abbr_abbreviation=$test_abbr_expansion
+		ztr test '[[ -z $(abbr expand "$prefix_glob_mismatch$test_abbr_abbreviation") ]]' \
+			"Can expand an abbreviation, prefixed with a glob, in a script — 3/n" \
 			"Dependencies: erase"
 
 		abbr $test_abbr_abbreviation_multiword=$test_abbr_expansion

--- a/tests/abbr-expand.ztr.zsh
+++ b/tests/abbr-expand.ztr.zsh
@@ -71,18 +71,43 @@ main() {
 			"Dependencies: erase"
 
 		abbr add $test_abbr_abbreviation=$test_abbr_expansion
-		ztr test '[[ $(abbr expand "$prefix_glob_match_1$test_abbr_abbreviation") == "$prefix_glob_match_1$test_abbr_expansion" ]]' \
+		ztr test '[[ $(abbr expand "$prefix_glob_1_match_1$test_abbr_abbreviation") == "$prefix_glob_1_match_1$test_abbr_expansion" ]]' \
 			"Can expand an abbreviation, prefixed with a glob, in a script — 1/n" \
 			"Dependencies: erase"
 
 		abbr add $test_abbr_abbreviation=$test_abbr_expansion
-		ztr test '[[ $(abbr expand "$prefix_glob_match_2$test_abbr_abbreviation") == "$prefix_glob_match_2$test_abbr_expansion" ]]' \
+		ztr test '[[ $(abbr expand "$prefix_glob_1_match_2$test_abbr_abbreviation") == "$prefix_glob_1_match_2$test_abbr_expansion" ]]' \
 			"Can expand an abbreviation, prefixed with a glob, in a script — 2/n" \
 			"Dependencies: erase"
 
 		abbr add $test_abbr_abbreviation=$test_abbr_expansion
-		ztr test '[[ -z $(abbr expand "$prefix_glob_mismatch$test_abbr_abbreviation") ]]' \
+		ztr test '[[ -z $(abbr expand "$prefix_glob_1_mismatch$test_abbr_abbreviation") ]]' \
 			"Can expand an abbreviation, prefixed with a glob, in a script — 3/n" \
+			"Dependencies: erase"
+
+		abbr add $test_abbr_abbreviation=$test_abbr_expansion
+		ztr test '[[ $(abbr expand "$prefix_multi_word$prefix_double_quotes$test_abbr_abbreviation") == "$prefix_multi_word$prefix_double_quotes$test_abbr_expansion" ]]' \
+			"Can expand an abbreviation, prefixed with a linear combination of scalar prefixes, in a script" \
+			"Dependencies: erase"
+
+		abbr add -S $test_abbr_abbreviation=$test_abbr_expansion
+		ztr test '[[ $(abbr expand "$prefix_glob_1_match_1$prefix_glob_2_match$test_abbr_abbreviation") == "$prefix_glob_1_match_1$prefix_glob_2_match$test_abbr_expansion" ]]' \
+			"Can expand a session abbreviation, prefixed with a linear combination of glob prefixes, in a script" \
+			"Dependencies: erase"
+
+		abbr add -S $test_abbr_abbreviation=$test_abbr_expansion
+		ztr test '[[ $(abbr expand "$prefix_double_quotes$prefix_glob_2_match$test_abbr_abbreviation") == "$prefix_double_quotes$prefix_glob_2_match$test_abbr_expansion" ]]' \
+			"Can expand a session abbreviation, prefixed with a scalar prefix followed by a glob prefix, in a script" \
+			"Dependencies: erase"
+
+		abbr add -S $test_abbr_abbreviation=$test_abbr_expansion
+		ztr test '[[ $(abbr expand "$prefix_glob_2_match$prefix_double_quotes$test_abbr_abbreviation") == "$prefix_glob_2_match$prefix_double_quotes$test_abbr_expansion" ]]' \
+			"Can expand a session abbreviation, prefixed with a glob prefix followed by a scalar prefix, in a script" \
+			"Dependencies: erase"
+
+		abbr add -S $test_abbr_abbreviation=$test_abbr_expansion
+		ztr test '[[ $(abbr expand "$prefix_glob_1_match_1$prefix_glob_2_match$prefix_double_quotes$prefix_multi_word$test_abbr_abbreviation") == "$prefix_glob_1_match_1$prefix_glob_2_match$prefix_double_quotes$prefix_multi_word$test_abbr_expansion" ]]' \
+			"Can expand a session abbreviation, prefixed with mixed glob and scalar prefixes, in a script" \
 			"Dependencies: erase"
 
 		abbr $test_abbr_abbreviation_multiword=$test_abbr_expansion

--- a/tests/abbr-expand.ztr.zsh
+++ b/tests/abbr-expand.ztr.zsh
@@ -30,6 +30,46 @@ main() {
 			"Can expand a global session abbreviation in a script" \
 			"Dependencies: erase"
 
+		abbr add $test_abbr_abbreviation=$test_abbr_expansion
+		ztr test '[[ $(abbr expand "$ABBR_REGULAR_ABBREVIATION_PREFIXES[1]$test_abbr_abbreviation") == "$ABBR_REGULAR_ABBREVIATION_PREFIXES[1]$test_abbr_expansion" ]]' \
+			"Can expand an abbreviation, prefixed with one word, in a script" \
+			"Dependencies: erase"
+
+		abbr add -S $test_abbr_abbreviation=$test_abbr_expansion
+		ztr test '[[ $(abbr expand "$ABBR_REGULAR_ABBREVIATION_PREFIXES[1]$test_abbr_abbreviation") == "$ABBR_REGULAR_ABBREVIATION_PREFIXES[1]$test_abbr_expansion" ]]' \
+			"Can expand a session abbreviation, prefixed with one word, in a script" \
+			"Dependencies: erase"
+
+		abbr add $test_abbr_abbreviation=$test_abbr_expansion
+		ztr test '[[ $(abbr expand "$ABBR_REGULAR_ABBREVIATION_PREFIXES[2]$test_abbr_abbreviation") == "$ABBR_REGULAR_ABBREVIATION_PREFIXES[2]$test_abbr_expansion" ]]' \
+			"Can expand an abbreviation, prefixed with multiple words, in a script" \
+			"Dependencies: erase"
+
+		abbr add -S $test_abbr_abbreviation=$test_abbr_expansion
+		ztr test '[[ $(abbr expand "$ABBR_REGULAR_ABBREVIATION_PREFIXES[2]$test_abbr_abbreviation") == "$ABBR_REGULAR_ABBREVIATION_PREFIXES[2]$test_abbr_expansion" ]]' \
+			"Can expand a session abbreviation, prefixed with multiple words, in a script" \
+			"Dependencies: erase"
+
+		abbr add $test_abbr_abbreviation=$test_abbr_expansion
+		ztr test '[[ $(abbr expand "$ABBR_REGULAR_ABBREVIATION_PREFIXES[3]$test_abbr_abbreviation") == "$ABBR_REGULAR_ABBREVIATION_PREFIXES[3]$test_abbr_expansion" ]]' \
+			"Can expand an abbreviation, prefixed with a prefix containing single-quoted double quotes, in a script" \
+			"Dependencies: erase"
+
+		abbr add -S $test_abbr_abbreviation=$test_abbr_expansion
+		ztr test '[[ $(abbr expand "$ABBR_REGULAR_ABBREVIATION_PREFIXES[3]$test_abbr_abbreviation") == "$ABBR_REGULAR_ABBREVIATION_PREFIXES[3]$test_abbr_expansion" ]]' \
+			"Can expand a session abbreviation, prefixed with a prefix containing single-quoted double quotes, in a script" \
+			"Dependencies: erase"
+
+		abbr add $test_abbr_abbreviation=$test_abbr_expansion
+		ztr test '[[ $(abbr expand "$ABBR_REGULAR_ABBREVIATION_PREFIXES[4]$test_abbr_abbreviation") == "$ABBR_REGULAR_ABBREVIATION_PREFIXES[4]$test_abbr_expansion" ]]' \
+			"Can expand an abbreviation, prefixed with a prefix containing double-quoted single quotes, in a script" \
+			"Dependencies: erase"
+
+		abbr add -S $test_abbr_abbreviation=$test_abbr_expansion
+		ztr test '[[ $(abbr expand "$ABBR_REGULAR_ABBREVIATION_PREFIXES[4]$test_abbr_abbreviation") == "$ABBR_REGULAR_ABBREVIATION_PREFIXES[4]$test_abbr_expansion" ]]' \
+			"Can expand a session abbreviation, prefixed with a prefix containing double-quoted single quotes, in a script" \
+			"Dependencies: erase"
+
 		abbr $test_abbr_abbreviation_multiword=$test_abbr_expansion
 		ztr test '[[ $(abbr expand $test_abbr_abbreviation_multiword) == $test_abbr_expansion ]]' \
 			"Can expand a two-word abbreviation in a script" \

--- a/tests/index.ztr.zsh
+++ b/tests/index.ztr.zsh
@@ -67,6 +67,7 @@ main() {
 	# Save user configuration
 	abbr_expansion_cursor_marker_saved=$ABBR_EXPANSION_CURSOR_MARKER
 	abbr_line_cursor_marker_saved=$ABBR_LINE_CURSOR_MARKER
+	abbr_prefixes_saved=( $ABBR_REGULAR_ABBREVIATION_PREFIXES )
 	abbr_quiet_saved=$ABBR_QUIET
 	abbr_tmpdir_saved=$ABBR_TMPDIR
 	ABBR_USER_ABBREVIATIONS_FILE_SAVED=$ABBR_USER_ABBREVIATIONS_FILE
@@ -75,6 +76,7 @@ main() {
 	# Configure
 	unset ABBR_EXPANSION_CURSOR_MARKER
 	unset ABBR_LINE_CURSOR_MARKER
+	ABBR_REGULAR_ABBREVIATION_PREFIXES=( one_word_prefix "multi-word prefix" 'prefix with "double quotes"' "prefix with 'single quotes'" )
 	ABBR_QUIET=1
 	ABBR_USER_ABBREVIATIONS_FILE=$test_dir/abbreviations.$RANDOM.tmp
 	ABBR_TMPDIR=$test_tmpdir
@@ -113,6 +115,7 @@ main() {
 
 	# Reset
 	ABBR_EXPANSION_CURSOR_MARKER=$abbr_expansion_cursor_marker_saved
+	ABBR_REGULAR_ABBREVIATION_PREFIXES=( $abbr_prefixes_saved )
 	ABBR_LINE_CURSOR_MARKER=$abbr_line_cursor_marker_saved
 	ABBR_QUIET=$abbr_quiet_saved
 	ABBR_TMPDIR=$abbr_tmpdir_saved

--- a/tests/index.ztr.zsh
+++ b/tests/index.ztr.zsh
@@ -66,14 +66,16 @@ main() {
 	fi
 
 	prefix_double_quotes='prefix with "double quotes"'
-	prefix_glob="?*globprefix"
+	prefix_glob_1="?*globprefix1"
+	prefix_glob_2="?*globprefix2"
 	prefix_multi_word="multi-word prefix"
 	prefix_one_word=one_word_prefix
 	prefix_single_quotes="prefix with 'single quotes'"
 
-	prefix_glob_match_1='.globprefix'
-	prefix_glob_match_2='..globprefix'
-	prefix_glob_mismatch='globprefix'
+	prefix_glob_1_match_1='.globprefix1'
+	prefix_glob_1_match_2='..globprefix1'
+	prefix_glob_1_mismatch='globprefix1'
+	prefix_glob_2_match='.globprefix2'
 
 	test_dir=$abbr_dir/tests
 
@@ -104,7 +106,8 @@ main() {
 	ABBR_REGULAR_ABBREVIATION_SCALAR_PREFIXES+=( $prefix_single_quotes )
 
 	typeset -a ABBR_REGULAR_ABBREVIATION_GLOB_PREFIXES=( )
-	ABBR_REGULAR_ABBREVIATION_GLOB_PREFIXES+=( $prefix_glob )
+	ABBR_REGULAR_ABBREVIATION_GLOB_PREFIXES+=( $prefix_glob_1 )
+	ABBR_REGULAR_ABBREVIATION_GLOB_PREFIXES+=( $prefix_glob_2 )
 
 	ABBR_QUIET=1
 	ABBR_USER_ABBREVIATIONS_FILE=$test_dir/abbreviations.$RANDOM.tmp

--- a/tests/index.ztr.zsh
+++ b/tests/index.ztr.zsh
@@ -28,6 +28,14 @@ main() {
 		abbr_tmpdir_saved \
 		aliases_saved \
 		cmd \
+		prefix_double_quotes \
+		prefix_glob \
+		prefix_glob_match_1 \
+		prefix_glob_match_2 \
+		prefix_glob_mismatch \
+		prefix_multi_word \
+		prefix_one_word \
+		prefix_single_quotes \
 		test_abbr_abbreviation \
 		test_abbr_abbreviation_2 \
 		test_abbr_abbreviation_multiword \
@@ -38,7 +46,8 @@ main() {
 		test_prefix \
 		test_tmpdir
 
-	local -a abbr_prefixes_saved
+	local -a abbr_scalar_prefixes_saved
+	local -a abbr_glob_prefixes_saved
 	
 	local -i abbr_quiet_saved
 
@@ -56,6 +65,16 @@ main() {
 		abbr_dir+=/..
 	fi
 
+	prefix_double_quotes='prefix with "double quotes"'
+	prefix_glob="?*globprefix"
+	prefix_multi_word="multi-word prefix"
+	prefix_one_word=one_word_prefix
+	prefix_single_quotes="prefix with 'single quotes'"
+
+	prefix_glob_match_1='.globprefix'
+	prefix_glob_match_2='..globprefix'
+	prefix_glob_mismatch='globprefix'
+
 	test_dir=$abbr_dir/tests
 
 	if [[ ${(%):-%#} == '#' ]]; then
@@ -66,9 +85,10 @@ main() {
 
 	# Save user configuration
 	abbr_expansion_cursor_marker_saved=$ABBR_EXPANSION_CURSOR_MARKER
+	abbr_glob_prefixes_saved=( $ABBR_REGULAR_ABBREVIATION_GLOB_PREFIXES )
 	abbr_line_cursor_marker_saved=$ABBR_LINE_CURSOR_MARKER
-	abbr_prefixes_saved=( $ABBR_REGULAR_ABBREVIATION_PREFIXES )
 	abbr_quiet_saved=$ABBR_QUIET
+	abbr_scalar_prefixes_saved=( $ABBR_REGULAR_ABBREVIATION_SCALAR_PREFIXES )
 	abbr_tmpdir_saved=$ABBR_TMPDIR
 	ABBR_USER_ABBREVIATIONS_FILE_SAVED=$ABBR_USER_ABBREVIATIONS_FILE
 	aliases_saved=$(alias -L)
@@ -76,7 +96,16 @@ main() {
 	# Configure
 	unset ABBR_EXPANSION_CURSOR_MARKER
 	unset ABBR_LINE_CURSOR_MARKER
-	ABBR_REGULAR_ABBREVIATION_PREFIXES=( one_word_prefix "multi-word prefix" 'prefix with "double quotes"' "prefix with 'single quotes'" )
+	
+	typeset -a ABBR_REGULAR_ABBREVIATION_SCALAR_PREFIXES=( )
+	ABBR_REGULAR_ABBREVIATION_SCALAR_PREFIXES+=( $prefix_double_quotes )
+	ABBR_REGULAR_ABBREVIATION_SCALAR_PREFIXES+=( $prefix_multi_word )
+	ABBR_REGULAR_ABBREVIATION_SCALAR_PREFIXES+=( $prefix_one_word )
+	ABBR_REGULAR_ABBREVIATION_SCALAR_PREFIXES+=( $prefix_single_quotes )
+
+	typeset -a ABBR_REGULAR_ABBREVIATION_GLOB_PREFIXES=( )
+	ABBR_REGULAR_ABBREVIATION_GLOB_PREFIXES+=( $prefix_glob )
+
 	ABBR_QUIET=1
 	ABBR_USER_ABBREVIATIONS_FILE=$test_dir/abbreviations.$RANDOM.tmp
 	ABBR_TMPDIR=$test_tmpdir
@@ -115,8 +144,9 @@ main() {
 
 	# Reset
 	ABBR_EXPANSION_CURSOR_MARKER=$abbr_expansion_cursor_marker_saved
-	ABBR_REGULAR_ABBREVIATION_PREFIXES=( $abbr_prefixes_saved )
 	ABBR_LINE_CURSOR_MARKER=$abbr_line_cursor_marker_saved
+	ABBR_REGULAR_ABBREVIATION_GLOB_PREFIXES=( $abbr_glob_prefixes_saved )
+	ABBR_REGULAR_ABBREVIATION_SCALAR_PREFIXES=( $abbr_scalar_prefixes_saved )
 	ABBR_QUIET=$abbr_quiet_saved
 	ABBR_TMPDIR=$abbr_tmpdir_saved
 	ABBR_USER_ABBREVIATIONS_FILE=$ABBR_USER_ABBREVIATIONS_FILE_SAVED

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -61,10 +61,13 @@ if [[ -z $ABBR_USER_ABBREVIATIONS_FILE ]]; then
   fi
 fi
 
-if ! [[ -n ${(t)ABBR_REGULAR_ABBREVIATION_PREFIXES} ]]; then
-  ABBR_REGULAR_ABBREVIATION_PREFIXES=( 'sudo ' )
+if [[ ${(t)ABBR_REGULAR_ABBREVIATION_SCALAR_PREFIXES} == ${${(t)ABBR_REGULAR_ABBREVIATION_SCALAR_PREFIXES}#array} ]]; then
+  typeset -ga ABBR_REGULAR_ABBREVIATION_SCALAR_PREFIXES=( 'sudo ' )
 fi
-typeset -ga ABBR_REGULAR_ABBREVIATION_PREFIXES
+
+if [[ ${(t)ABBR_REGULAR_ABBREVIATION_GLOB_PREFIXES} == ${${(t)ABBR_REGULAR_ABBREVIATION_GLOB_PREFIXES}#array} ]]; then
+  typeset -ga ABBR_REGULAR_ABBREVIATION_GLOB_PREFIXES=( )
+fi
 
 # FUNCTIONS
 # ---------
@@ -1037,48 +1040,79 @@ _abbr_regular_expansion() {
     local expansion
 
     _abbr_regular_expansion:get_expansion() {
-      # cannot support debug message
+      {
+        # cannot support debug message
 
-      local abbreviation
-      local abbreviation_sans_prefix
-      local expansion
-      local prefix
-      local -a prefixes
-      local -i session
+        _abbr_regular_expansion:get_expansion:get_prefixed_expansion() {
+          # cannot support debug message
+          
+          local abbreviation_sans_prefix
+          local prefix
+          local -a prefixes
+          local -i use_globbing
+          
+          use_globbing=$1
 
-      abbreviation=$1
-      session=$2
+          prefixes=( $ABBR_REGULAR_ABBREVIATION_SCALAR_PREFIXES )
 
-      prefixes=( $ABBR_REGULAR_ABBREVIATION_PREFIXES )
+          (( use_globbing )) && prefixes=( $ABBR_REGULAR_ABBREVIATION_GLOB_PREFIXES )
 
-      if (( session )); then
-        expansion=$ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]
-      else
-        expansion=$ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]
-      fi
+          while [[ ! $expansion ]] && (( #prefixes )); do
+            prefix=$prefixes[1]
+            shift prefixes
 
-      while [[ ! $expansion ]] && (( #prefixes )); do
-        prefix=$prefixes[1]
-        shift prefixes
+            abbreviation_sans_prefix="${abbreviation#$prefix}"
 
-        abbreviation_sans_prefix="${abbreviation#$prefix}"
+            if (( use_globbing )); then
+              # Trim the remainder of $prefix, _as a glob_ (`$~globparam` vs `$stringparam`)_, from $abbreviation
+              abbreviation_sans_prefix=${abbreviation#$~prefix}
+            fi
+
+            # $abbreviation_sans_prefix is now the full $abbreviation if $abbreviation doesn't start with a prefix,
+            # or a $abbreviation with the prefix trimmed if $abbreviation does start with a prefix
+
+            if (( session )); then
+              expansion=$ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)abbreviation_sans_prefix}]
+            else
+              expansion=$ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation_sans_prefix}]
+            fi
+
+            if [[ ! $expansion ]]; then
+              continue
+            fi
+
+            # Re-prepend anything trimmed off during the prefix check
+            expansion="${(qqq)${abbreviation%$abbreviation_sans_prefix}}$expansion"
+          done
+
+          'builtin' 'echo' - $expansion
+        }
+
+        local abbreviation
+        local expansion
+        local -i session
+
+        abbreviation=$1
+        session=$2
 
         if (( session )); then
-          expansion=$ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)abbreviation_sans_prefix}]
+          expansion=$ABBR_REGULAR_SESSION_ABBREVIATIONS[${(qqq)abbreviation}]
         else
-          expansion=$ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation_sans_prefix}]
+          expansion=$ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation}]
         fi
 
         if [[ ! $expansion ]]; then
-          continue
+          expansion=$(_abbr_regular_expansion:get_expansion:get_prefixed_expansion 1)
         fi
 
-        if [[ $abbreviation_sans_prefix != $abbreviation ]]; then
-          expansion="${(qqq)prefix}$expansion"
+        if [[ ! $expansion ]]; then
+          expansion=$(_abbr_regular_expansion:get_expansion:get_prefixed_expansion 0)
         fi
-      done
 
-      'builtin' 'echo' - $expansion
+        'builtin' 'echo' - $expansion
+      } always {
+        unfunction -m _abbr_regular_expansion:get_expansion:get_prefixed_expansion
+      }
     }
 
     abbreviation=$1

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -1046,27 +1046,32 @@ _abbr_regular_expansion() {
         _abbr_regular_expansion:get_expansion:get_prefixed_expansion() {
           # cannot support debug message
           
+          local abbreviation
           local abbreviation_sans_prefix
           local prefix
+          local prefix_pattern
           local -a prefixes
           local -i use_globbing
           
-          use_globbing=$1
+          abbreviation=$1
+          use_globbing=$2
 
           prefixes=( $ABBR_REGULAR_ABBREVIATION_SCALAR_PREFIXES )
 
           (( use_globbing )) && prefixes=( $ABBR_REGULAR_ABBREVIATION_GLOB_PREFIXES )
 
           while [[ ! $expansion ]] && (( #prefixes )); do
-            prefix=$prefixes[1]
+            prefix_pattern=$prefixes[1]
             shift prefixes
 
-            abbreviation_sans_prefix="${abbreviation#$prefix}"
+            abbreviation_sans_prefix="${abbreviation#$prefix_pattern}"
 
             if (( use_globbing )); then
               # Trim the remainder of $prefix, _as a glob_ (`$~globparam` vs `$stringparam`)_, from $abbreviation
-              abbreviation_sans_prefix=${abbreviation#$~prefix}
+              abbreviation_sans_prefix=${abbreviation#$~prefix_pattern}
             fi
+
+            prefix=${abbreviation%$abbreviation_sans_prefix}
 
             # $abbreviation_sans_prefix is now the full $abbreviation if $abbreviation doesn't start with a prefix,
             # or a $abbreviation with the prefix trimmed if $abbreviation does start with a prefix
@@ -1077,12 +1082,22 @@ _abbr_regular_expansion() {
               expansion=$ABBR_REGULAR_USER_ABBREVIATIONS[${(qqq)abbreviation_sans_prefix}]
             fi
 
+            if [[ -n $prefix ]]; then
+              if [[ ! $expansion ]]; then
+                expansion=$(_abbr_regular_expansion:get_expansion:get_prefixed_expansion $abbreviation_sans_prefix 1)
+              fi
+
+              if [[ ! $expansion ]]; then
+                expansion=$(_abbr_regular_expansion:get_expansion:get_prefixed_expansion $abbreviation_sans_prefix 0)
+              fi
+            fi
+
             if [[ ! $expansion ]]; then
               continue
             fi
 
             # Re-prepend anything trimmed off during the prefix check
-            expansion="${(qqq)${abbreviation%$abbreviation_sans_prefix}}$expansion"
+            expansion="${(qqq)prefix}$expansion"
           done
 
           'builtin' 'echo' - $expansion
@@ -1102,11 +1117,11 @@ _abbr_regular_expansion() {
         fi
 
         if [[ ! $expansion ]]; then
-          expansion=$(_abbr_regular_expansion:get_expansion:get_prefixed_expansion 1)
+          expansion=$(_abbr_regular_expansion:get_expansion:get_prefixed_expansion $abbreviation 1)
         fi
 
         if [[ ! $expansion ]]; then
-          expansion=$(_abbr_regular_expansion:get_expansion:get_prefixed_expansion 0)
+          expansion=$(_abbr_regular_expansion:get_expansion:get_prefixed_expansion $abbreviation 0)
         fi
 
         'builtin' 'echo' - $expansion


### PR DESCRIPTION
Rebases `prefixes/prefixes` with `v6`. See the work in

- #137
- #138 
- #139