### PR TITLE
Fix reminder not parsing message properly

### DIFF
--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -1517,7 +1517,7 @@ _abbr_log_available_abbreviation() {
     message="$style$message%f"
   fi
 
-  'builtin' 'print' -P '$message'
+  'builtin' 'print' -P $message
 }
 
 # WIDGETS


### PR DESCRIPTION
Fixes #173, tested on NixOS

The mentioned section was the cause of the bug: https://github.com/olets/zsh-abbr/blob/f9e43d78110db0a8bf8ec75ca5b101a06b1d5ce8/zsh-abbr.zsh#L1520

Removing the quotation from the message variable made it work properly 👍🏾 