### PR TITLE
fix(man): Fix the current ABBR_USER_ABBREVIATIONS_FILE

### DIFF
--- a/man/man1/abbr.1
+++ b/man/man1/abbr.1
@@ -218,7 +218,7 @@ Behave as if `--quiet` was passed? (0 or 1, default 0)
 
 .IP \(bu
 \fIABBR_USER_ABBREVIATIONS_FILE\fR
-File abbreviations are stored in (default ${HOME}/.config/zsh/abbreviations)
+File abbreviations are stored in (default ${HOME}/.config/zsh-abbr/user-abbreviations)
 
 .IP \(bu
 \fINO_COLOR\fR


### PR DESCRIPTION
Hello! I'm new to zsh-abbr and just beginning to explore its features.

I noticed a potential typo in the help page regarding the default value of $ABBR_USER_ABBREVIATIONS_FILE.
The documentation currently states the default path as `${HOME}/.config/zsh/abbreviations`, but my understanding is that it has been updated to `${HOME}/.config/zsh-abbr/user-abbreviations`.

Could you please confirm this, and if correct, I'd like to update the documentation to reflect the current default path?