### PR TITLE
fix(completions): preserve _abbr completion function [#210]

### DIFF
--- a/tests/_completion.ztr.zsh
+++ b/tests/_completion.ztr.zsh
@@ -1,0 +1,10 @@
+#!/usr/bin/env zsh
+
+main() {
+  emulate -LR zsh
+
+  ztr test '(( $+functions[_abbr] ))' \
+    "Sourcing the plugin does not remove the shipped _abbr completion function (issue #210)"
+}
+
+main

--- a/tests/_completion.ztr.zsh
+++ b/tests/_completion.ztr.zsh
@@ -4,7 +4,7 @@ main() {
   emulate -LR zsh
 
   ztr test '(( $+functions[_abbr] ))' \
-    "Sourcing the plugin does not remove the shipped _abbr completion function (issue #210)"
+    "Completions function is available"
 }
 
 main

--- a/tests/index.ztr.zsh
+++ b/tests/index.ztr.zsh
@@ -144,9 +144,8 @@ main() {
   test_abbr_expansion="zsh abbr test"
   test_abbr_expansion_2="zsh abbr test 2"
 
-  # Autoload the shipped completion function (regression guard for #210).
-  # The fpath addition persists for the rest of the suite; harmless.
-  fpath=( $abbr_dir/completions $fpath )
+  # As done by zsh-abbr.plugin.zsh
+  fpath+=$abbr_dir/completions
   autoload -Uz _abbr
 
   # Source dependencies

--- a/tests/index.ztr.zsh
+++ b/tests/index.ztr.zsh
@@ -144,6 +144,11 @@ main() {
   test_abbr_expansion="zsh abbr test"
   test_abbr_expansion_2="zsh abbr test 2"
 
+  # Autoload the shipped completion function (regression guard for #210).
+  # The fpath addition persists for the rest of the suite; harmless.
+  fpath=( $abbr_dir/completions $fpath )
+  autoload -Uz _abbr
+
   # Source dependencies
   . $abbr_dir/zsh-abbr.zsh
   . $ztr_path

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -2182,6 +2182,7 @@ _abbr_init
 # _abbr_tmpdir
 
 # can't unfunction
+# _abbr (name collision with shipped completion function completions/_abbr)
 # _abbr_accept-line
 # _abbr_create_files
 # _abbr_debugger
@@ -2192,7 +2193,6 @@ _abbr_init
 # _abbr_no_color
 # _abbr_regular_expansion
 
-unfunction -m _abbr
 unfunction -m _abbr_init
 unfunction -m _abbr_warn_deprecation
 unfunction -m _abbr:add

--- a/zsh-abbr.zsh
+++ b/zsh-abbr.zsh
@@ -2182,7 +2182,7 @@ _abbr_init
 # _abbr_tmpdir
 
 # can't unfunction
-# _abbr (name collision with shipped completion function completions/_abbr)
+# _abbr (see completions)
 # _abbr_accept-line
 # _abbr_create_files
 # _abbr_debugger


### PR DESCRIPTION
Fixes #210

The `unfunction -m _abbr` in the post-init cleanup was clobbering the shipped completion function `completions/_abbr` that the user's `compinit` had autoloaded. The plugin never defines a function named `_abbr` itself.
